### PR TITLE
fix: instala dependências para esbuild funcionar corretamente

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -350,14 +350,6 @@ esbuild-plugin-vue3@^0.4.2:
     esbuild "^0.14.8"
     typescript "^4.7.4"
 
-esbuild-plugin-vue@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/esbuild-plugin-vue/-/esbuild-plugin-vue-0.2.4.tgz#921e1f076fed818fa36e08e8ed807a476923f6ae"
-  integrity sha512-1noq1Tnnv4WAgdt5UROuNNIwQ7ppE5jlLB2MQD+XdzgprmOksGNTZlAEyYYF8oPMkq0qk1GB8KJJMTr2aE2Nzg==
-  dependencies:
-    hash-sum "^2.0.0"
-    resolve-from "^5.0.0"
-
 esbuild-sunos-64@0.14.54:
   version "0.14.54"
   resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz#54287ee3da73d3844b721c21bc80c1dc7e1bf7da"
@@ -442,11 +434,6 @@ estree-walker@^2.0.2:
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
   integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
-hash-sum@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/hash-sum/-/hash-sum-2.0.0.tgz#81d01bb5de8ea4a214ad5d6ead1b523460b0b45a"
-  integrity sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==
-
 magic-string@^0.30.17:
   version "0.30.17"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.17.tgz#450a449673d2460e5bbcfba9a61916a1714c7453"
@@ -472,11 +459,6 @@ postcss@^8.5.6:
     nanoid "^3.3.11"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
-
-resolve-from@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
-  integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
 source-map-js@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
Este PR corrige a falha na execução do esbuild devido à falta de dependências essenciais que foram removidas ou não instaladas após a migração do Vite para esbuild.

Alterações feitas:
- Remoção de dependências obsoletas relacionadas ao Vite no yarn.lock.
- Ajuste no yarn.lock para garantir que o esbuild e seus plugins funcionem corretamente.
- Execução do yarn install para atualizar o lockfile.