### PR TITLE
Estiliza tela central do menu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,6 @@ RUN npm install -g yarn
 WORKDIR /app
 COPY . /app
 
+RUN yarn install
+
 CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -1,0 +1,3 @@
+class MenusController < ApplicationController
+  def show; end
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,6 +2,7 @@ import "./stylesheets/application.css";
 import { createApp } from 'vue'
 import App from './components/App.vue'
 import Dashboard from './components/dashboard/Dashboard.vue'
+import Menu from './components/menu/MenuCenter.vue'
 
 document.addEventListener('DOMContentLoaded', () => {
   const appEl = document.getElementById('app-vue')
@@ -12,5 +13,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const dashboardEl = document.getElementById('dashboard-widget')
   if (dashboardEl) {
     createApp(Dashboard).mount(dashboardEl)
+  }
+
+  const menuEl = document.getElementById('menu-widget')
+  if (menuEl) {
+    createApp(Menu).mount(menuEl)
   }
 })

--- a/app/javascript/components/dashboard/QuickActions.vue
+++ b/app/javascript/components/dashboard/QuickActions.vue
@@ -5,6 +5,7 @@
       v-for="action in actions"
       :key="action.label"
       class="quick-action-card"
+      @click="navigateTo(action.path)"
     >
       <div class="quick-action-icon"><Icon :icon="action.icon" /></div>
       <span class="quick-action-label">{{ action.label }}</span>
@@ -16,11 +17,15 @@
 import { Icon } from '@iconify/vue';
 
 const actions = [
-  { label: 'Gerenciar Menu', icon: 'tabler:chef-hat' },
-  { label: 'Ver Pedidos', icon: 'iconoir:bell' },
-  { label: 'Horários', icon: 'lucide:calendar' },
-  { label: 'Área de Entrega', icon: 'tdesign:location' }
+  { label: 'Gerenciar Menu', icon: 'tabler:chef-hat', path: '/menu' },
+  { label: 'Ver Pedidos', icon: 'iconoir:bell', path: '/orders' },
+  { label: 'Horários', icon: 'lucide:calendar', path: '/schedules' },
+  { label: 'Área de Entrega', icon: 'tdesign:location', path: '/delivery-area' }
 ]
+
+const navigateTo = (path) => {
+  if (path) window.location.href = path
+}
 </script>
 
 <style scoped>

--- a/app/javascript/components/menu/CardInfo.vue
+++ b/app/javascript/components/menu/CardInfo.vue
@@ -55,9 +55,26 @@ defineProps({
 }
 
 @media (max-width: 1000px) {
+  .info-card {
+    padding: 1rem 0;
+  }
+
   .info-icon {
     width: 3rem;
     height: 3rem;
   }
+
+  .info-value {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin: 1rem 0 0.5rem 0;
+  }
+
+  .info-label {
+    font-size: 1rem;
+    color: var(--color-muted);
+    margin: 0;
+  }
+
 }
 </style>

--- a/app/javascript/components/menu/CardInfo.vue
+++ b/app/javascript/components/menu/CardInfo.vue
@@ -1,0 +1,63 @@
+<template>
+  <div class="info-card">
+    <Icon :icon="icon" :style="{ color }" class="info-icon" />
+    <div class="info-content">
+      <p class="info-value">{{ value }}</p>
+      <p class="info-label">{{ label }}</p>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { Icon } from '@iconify/vue'
+
+defineProps({
+  icon: String,
+  label: String,
+  value: [String, Number],
+  color: String
+})
+</script>
+
+<style scoped>
+.info-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: var(--color-white);
+  border-radius: 8px;
+  padding: 2rem 0;
+  flex: 1;
+  border: 1px solid var(--color-border);
+}
+
+.info-icon {
+  width: 4rem;
+  height: 4rem;
+}
+
+.info-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.info-value {
+  font-size: 2.5rem;
+  font-weight: 600;
+  margin: 1rem 0 0.5rem 0;
+}
+
+.info-label {
+  font-size: 1.2rem;
+  color: var(--color-muted);
+  margin: 0;
+}
+
+@media (max-width: 1000px) {
+  .info-icon {
+    width: 3rem;
+    height: 3rem;
+  }
+}
+</style>

--- a/app/javascript/components/menu/CategoriesFilter.vue
+++ b/app/javascript/components/menu/CategoriesFilter.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="category-header">
+    <h2>Gerenciar Categorias</h2>
+    <AppButton text="Nova Categoria" class="btn-add" iconLeft="tabler:plus" />
+  </div>
+  <div class="dashboard-filters">
+    <SearchInput class="input" />
+  </div>
+</template>
+
+<script setup>
+import AppButton from '../ui/AppButton.vue';
+import SearchInput from '../ui/SearchInput.vue';
+</script>
+
+<style scoped>
+.category-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.input {
+  flex: 1;
+}
+
+.dashboard-filters {
+  display: flex;
+  justify-content: space-between;
+  background: var(--color-white);
+  border-radius: 8px;
+  padding: 1rem;
+  border: 1px solid var(--color-border);
+  gap: 1rem;
+}
+
+@media (max-width: 758px) {
+  .category-header {
+    flex-direction: column;
+    align-items: flex-start
+  }
+
+  .btn-add {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    margin-bottom: 1rem;
+  }
+
+  .input {
+    padding: 0;
+  }
+}
+</style>

--- a/app/javascript/components/menu/MenuCards.vue
+++ b/app/javascript/components/menu/MenuCards.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="menu-cards">
+    <CardInfo icon="tabler:package" label="Total de Produtos" value="0" color="orange" />
+    <CardInfo icon="tabler:eye" label="Produtos Ativos" value="0" color="green" />
+    <CardInfo icon="tabler:star" label="Em Destaque" value="0" color="yellow" />
+    <CardInfo icon="tabler:currency-dollar" label="Preço Médio" value="R$ 0.00" color="blue" />
+  </div>
+</template>
+
+<script setup>
+import CardInfo from './CardInfo.vue';
+
+</script>
+
+<style scoped>
+.menu-cards {
+  display: flex;
+  gap: 2em;
+  margin-bottom: 2rem;
+}
+
+@media (max-width: 1000px) {
+  .menu-cards {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 2em;
+  }
+}
+
+@media (max-width: 758px) {
+  .menu-cards {
+    display: flex;
+    flex-direction: column;
+    gap: 1em;
+  }
+}
+</style>

--- a/app/javascript/components/menu/MenuCenter.vue
+++ b/app/javascript/components/menu/MenuCenter.vue
@@ -1,0 +1,83 @@
+<template>
+  <div class="menu-overview">
+    <MenuOverview />
+  </div>
+  <div class="menu">
+    <div class="menu-dashboard">
+      <MenuCards />
+      <TabMenu @changeTab="handleTabChange" />
+
+      <div v-show="tab === 'products'" class="products-tab">
+        <ProductsMenuFilters @changeView="handleViewChange" />
+        <MenuEmptyState :product="true"/>
+      </div>
+
+      <div v-show="tab === 'categories'">
+        <CategoriesFilter
+          @changeView="handleViewChange"
+        />
+        <MenuEmptyState />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import MenuOverview from './MenuOverview.vue'
+import MenuCards from './MenuCards.vue'
+import ProductsMenuFilters from './ProductsMenuFilters.vue'
+import MenuEmptyState from './MenuEmptyState.vue'
+import TabMenu from './TabMenu.vue'
+import CategoriesFilter from './CategoriesFilter.vue'
+
+const tab = ref('products')
+
+function handleViewChange(view) {
+  console.log('Visualização selecionada:', view)
+}
+
+function handleTabChange(view) {
+  tab.value = view
+}
+</script>
+
+<style scoped>
+.menu-overview {
+  display: flex;
+  justify-content: center;
+}
+
+.menu {
+  display: flex;
+  justify-content: center;
+}
+
+.menu-dashboard {
+  display: flex;
+  flex-direction: column;
+  padding: 2rem;
+  gap: 2rem;
+  background-color: var(--color-background);
+  margin: 0 2rem;
+  width: 1820px;
+}
+
+.tab {
+  display: flex;
+  gap: 1rem;
+}
+
+@media (max-width: 758px) {
+  .menu-dashboard {
+    width: 100%;
+    margin: 0;
+    padding: 1rem;
+  }
+
+  .menu-overview header {
+    margin: 0;
+    padding: 1rem;
+  }
+}
+</style>

--- a/app/javascript/components/menu/MenuEmptyState.vue
+++ b/app/javascript/components/menu/MenuEmptyState.vue
@@ -1,0 +1,64 @@
+<template>
+  <div class="empty-box">
+    <Icon icon="tabler:package" class="empty-icon" />
+    <p class="empty-text">Nenhum {{ product ? 'produtos' : 'categorias' }} encontrado</p>
+    <p class="empty-subtext">Comece adicionando {{ product ? 'seu primeiro produto' : 'sua primeira categoria' }}</p>
+    <AppButton iconLeft="tabler:plus" :text="`Adicionar ${product ? 'Produtos' : 'Categorias'}`"/>
+  </div>
+</template>
+
+<script setup>
+import { Icon } from '@iconify/vue'
+import AppButton from '../ui/AppButton.vue';
+
+defineProps({
+  product: {
+    type: Boolean,
+    default: false,
+  }
+})
+</script>
+
+<style scoped>
+.empty-box {
+  background-color: var(--color-white);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 3rem;
+  text-align: center;
+  color: var(--color-muted);
+  margin-top: 2rem;
+}
+
+.empty-box p {
+  color: var(--color-muted);
+}
+
+.empty-icon {
+  width: 4.5rem;
+  height: 4.5rem;
+  margin-bottom: 1rem;
+  color: var(--color-border);
+}
+
+.empty-text {
+  font-weight: 600;
+  font-size: 1.2rem;
+  margin: 0;
+}
+
+.empty-subtext {
+  font-size: 1rem;
+  margin-bottom: 1rem;
+}
+
+.btn-primary {
+  background: var(--color-primary);
+  color: var(--color-white);
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 500;
+}
+</style>

--- a/app/javascript/components/menu/MenuOverview.vue
+++ b/app/javascript/components/menu/MenuOverview.vue
@@ -1,0 +1,111 @@
+<template>
+  <header class="dashboard-header">
+    <div>
+      <h1 class="title"><Icon icon="tabler:chef-hat" /> Central do Menu</h1>
+      <p class="subtitle">Gerencie seus produtos de forma simples e eficiente</p>
+    </div>
+    <div class="header-actions">
+      <AppButton text="Nova Categoria" iconLeft="tabler:plus" class="new-category" />
+      <AppButton text="Novo Produto" iconLeft="tabler:plus" />
+    </div>
+  </header>
+</template>
+
+<script setup>
+import { Icon } from '@iconify/vue'
+import AppButton from '../ui/AppButton.vue';
+</script>
+
+<style scoped>
+.dashboard-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  width: 100%;
+  border-bottom: 2px solid var(--color-border);
+  margin: 0 2rem;
+}
+
+.title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.5rem 0;
+}
+
+.title svg {
+  color: var(--color-primary);
+}
+
+.subtitle {
+  margin-top: 0.25rem;
+  color: var(--color-muted);
+}
+
+.header-actions {
+  display: flex;
+  gap: 1rem;
+}
+
+:deep(.new-category.cta-button) {
+  background-color: var(--color-white);
+  color: var(--color-black);
+  border: 1px solid var(--color-border);
+}
+
+:deep(.new-category.cta-button:hover) {
+  background-color: var(--color-border);
+}
+
+:deep(.cta-button) {
+  display: flex;
+  align-items: stretch;
+}
+
+.btn-outline {
+  background: var(--color-white);
+  border: 1px solid var(--color-border);
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.btn-primary {
+  background: var(--color-primary);
+  color: var(--color-white);
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+@media (max-width: 1000px) {
+  .dashboard-header {
+    flex-direction: column;
+    align-items: flex-start;
+    width: 100%;
+  }
+
+  .title {
+    margin: 0;
+  }
+
+  .subtitle {
+    font-size: 16px;
+  }
+
+  .header-actions {
+    width: 100%;
+    flex-direction: column;
+  }
+
+  :deep(.cta-button) {
+    justify-content: center;
+  }
+}
+</style>

--- a/app/javascript/components/menu/ProductsMenuFilters.vue
+++ b/app/javascript/components/menu/ProductsMenuFilters.vue
@@ -1,0 +1,129 @@
+<template>
+  <div class="dashboard-filters">
+    <SearchInput class="input" />
+    <div class="categories">
+      <CategoryDropdown
+        class="category-dropdown"
+        label="Todas as categorias"
+        :options="[
+          { label: 'Bebidas', value: 'bebidas' },
+          { label: 'Comidas', value: 'comidas' },
+          { label: 'Sobremesas', value: 'sobremesas' }
+        ]"
+      />
+      <div class="view-buttons">
+        <button
+          class="btn-icon"
+          :class="{ active: activeView === 'grid' }"
+          @click="setView('grid')"
+        >
+          <Icon icon="ic:round-grid-on" class="icon"/>
+          <span>Grade</span>
+        </button>
+        <button
+          class="btn-icon"
+          :class="{ active: activeView === 'list' }"
+          @click="setView('list')"
+        >
+          <Icon icon="material-symbols:list-rounded" class="icon"/>
+          <span>Lista</span>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import { Icon } from '@iconify/vue'
+import SearchInput from '../ui/SearchInput.vue';
+import CategoryDropdown from '../ui/CategoryDropdown.vue';
+
+const emit = defineEmits(['changeView'])
+const activeView = ref('grid')
+
+function setView(view) {
+  activeView.value = view
+  emit('changeView', view)
+}
+</script>
+
+<style scoped>
+.dashboard-filters {
+  display: flex;
+  justify-content: space-between;
+  background: var(--color-white);
+  border-radius: 8px;
+  padding: 1rem;
+  border: 1px solid var(--color-border);
+  gap: 1rem;
+}
+
+.input {
+  flex: 1;
+}
+
+.categories {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.view-buttons {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.btn-icon {
+  background: var(--color-white);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  padding: 0.4rem 1.2rem 0.4rem 0.7rem;
+  cursor: pointer;
+  color: var(--color-black);
+  display: flex;
+
+  span {
+    display: none;
+  }
+}
+
+.btn-icon.active {
+  background: var(--color-primary);
+  color: var(--color-white);
+  border-color: var(--color-primary);
+}
+
+.icon {
+  width: 1.3rem;
+  height: 1.3rem;
+}
+
+@media (max-width: 758px) {
+  .dashboard-filters {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .input {
+    padding: 0;
+  }
+
+  .category-dropdown {
+    padding: 0;
+    width: 100%;
+  }
+
+  .btn-icon {
+    width: 100%;
+    justify-content: center;
+    align-items: center;
+    gap: 1rem;
+
+    span {
+      display: block;
+    }
+  }
+}
+</style>

--- a/app/javascript/components/menu/TabMenu.vue
+++ b/app/javascript/components/menu/TabMenu.vue
@@ -1,0 +1,75 @@
+<template>
+  <div class="tab-container">
+    <div class="tab">
+      <span
+        :class="{ active: currentTab === 'products' }"
+        @click="selectTab('products')"
+      >
+        Produtos
+      </span>
+      <span
+        :class="{ active: currentTab === 'categories' }"
+        @click="selectTab('categories')"
+      >
+        Categorias
+      </span>
+    </div>
+    <div class="underline-container">
+      <div
+        class="underline"
+        :style="{ transform: currentTab === 'products' ? 'translateX(0%)' : 'translateX(113%)' }"
+      ></div>
+    </div>
+    <hr />
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+const emit = defineEmits('changeTab')
+
+const currentTab = ref('products')
+
+function selectTab(tab) {
+  currentTab.value = tab
+  emit('changeTab', tab)
+}
+</script>
+
+<style scoped>
+.tab-container {
+  width: 100%;
+}
+
+.tab {
+  display: flex;
+  gap: 1rem;
+  padding-bottom: 1rem;
+}
+
+.tab span {
+  font-weight: 500;
+  color: var(--color-muted);
+  cursor: pointer;
+  transition: color 0.2s;
+  margin-left: 0.7rem;
+}
+
+.tab span.active {
+  color: var(--color-primary);
+}
+
+.underline-container {
+  position: relative;
+  height: 0px;
+  margin-top: -2px;
+}
+
+.underline {
+  width: 90px;
+  height: 2px;
+  background-color: var(--color-primary);
+  transition: transform 0.3s;
+}
+</style>

--- a/app/javascript/components/ui/CategoryDropdown.vue
+++ b/app/javascript/components/ui/CategoryDropdown.vue
@@ -1,0 +1,138 @@
+<template>
+  <div class="dropdown-wrapper" @click="toggleDropdown">
+    <div class="dropdown-display">
+      <span>{{ selectedLabel }}</span>
+      <Icon icon="line-md:chevron-down" class="dropdown-icon" />
+    </div>
+
+    <div v-if="isOpen" class="dropdown-menu">
+      <div
+        v-for="option in allOptions"
+        :key="option.value"
+        class="dropdown-item"
+        :class="{ selected: option.value === selected }"
+        @click.stop="selectOption(option.value)"
+      >
+        <Icon
+          v-if="option.value === selected"
+          icon="material-symbols:check-rounded"
+          class="check-icon"
+        />
+        <span>{{ option.label }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue'
+import { Icon } from '@iconify/vue'
+
+const props = defineProps({
+  label: {
+    type: String,
+    default: 'Todas as categorias',
+  },
+  options: {
+    type: Array,
+    default: () => [],
+  },
+  modelValue: {
+    type: String,
+    default: '',
+  },
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const selected = ref(props.modelValue)
+const isOpen = ref(false)
+
+watch(() => props.modelValue, (newVal) => {
+  selected.value = newVal
+})
+
+const toggleDropdown = () => {
+  isOpen.value = !isOpen.value
+}
+
+const selectOption = (value) => {
+  selected.value = value
+  emit('update:modelValue', value)
+  isOpen.value = false
+}
+
+const allOptions = computed(() => [
+  { label: props.label, value: '' },
+  ...props.options,
+])
+
+const selectedLabel = computed(() => {
+  const selectedOption = allOptions.value.find(o => o.value === selected.value)
+  return selectedOption ? selectedOption.label : props.label
+})
+</script>
+
+<style scoped>
+.dropdown-wrapper {
+  position: relative;
+  width: 250px;
+  font-size: 14px;
+}
+
+.dropdown-display {
+  padding: 0.7rem 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background-color: var(--color-white);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+}
+
+.dropdown-icon {
+  color: var(--color-muted);
+}
+
+.dropdown-menu {
+  position: absolute;
+  top: 110%;
+  left: 0;
+  right: 0;
+  background: var(--color-white);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  z-index: 10;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.dropdown-item {
+  padding: 8px 12px;
+  cursor: pointer;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+}
+
+.dropdown-item span{
+  width: 100%;
+  display: flex;
+  justify-content: center
+}
+
+.dropdown-item:hover {
+  background-color: #f5f5f5;
+}
+
+.dropdown-item.selected {
+  background-color: #f0f4ff;
+}
+
+.check-icon {
+  height: 1.2rem;
+  width: 1.2rem;
+}
+</style>

--- a/app/javascript/components/ui/SearchInput.vue
+++ b/app/javascript/components/ui/SearchInput.vue
@@ -1,0 +1,85 @@
+<template>
+  <div class="floating-search">
+    <div class="search-bar">
+      <Icon class="search-icon" icon="fluent:search-32-regular" />
+      <input
+        type="text"
+        :placeholder="placeholder"
+        :value="modelValue"
+        @input="$emit('update:modelValue', $event.target.value)"
+      />
+      <Icon
+        v-if="modelValue"
+        class="close-icon"
+        icon="material-symbols-light:close"
+        @click="$emit('update:modelValue', '')"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { Icon } from '@iconify/vue';
+
+defineProps({
+  placeholder: {
+    type: String,
+    default: 'Buscar...'
+  },
+  modelValue: String
+})
+
+defineEmits(['update:modelValue', 'search'])
+</script>
+
+
+<style scoped>
+.floating-search {
+  position: sticky;
+  top: 100px;
+  z-index: 1;
+  overflow-x: auto;
+  background-color: var(--color-white);
+}
+
+.search-bar {
+  background: var(--color-white);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  position: relative;
+}
+
+.search-icon {
+  position: absolute;
+  left: 0.7rem;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  color: var(--color-muted);
+  font-size: 1.2rem;
+}
+
+.close-icon {
+  position: absolute;
+  right: 0.7rem;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: auto;
+  color: var(--color-primary);
+  font-size: 1.2rem;
+}
+
+.search-bar input {
+  padding: 0.7rem 0rem 0.7rem 2.3rem;
+  width: 100%;
+  border: 1px solid var(--color-border);
+  border-radius: 7px;
+}
+
+@media (max-width: 758px) {
+  .search-bar input {
+    width: 100%
+  }
+}
+</style>

--- a/app/views/menus/show.html.erb
+++ b/app/views/menus/show.html.erb
@@ -1,0 +1,1 @@
+<div id="menu-widget"></div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
   # get "up" => "rails/health#show", as: :rails_health_check
   root "dashboard#index"
+
+  get "/menu", to: "menus#show"
 end


### PR DESCRIPTION
# Fecha a issue #7 

## Descrição

Implementa a tela central do menu do restaurante, criando uma interface organizada para gerenciar produtos e categorias de forma simples e eficiente.

## Novos componentes Vue adicionados:

- **`MenuCenter`**: Componente principal que estrutura o layout do dashboard do menu.
- **`MenuOverview`**: Cabeçalho da tela com título e botões para adicionar categoria e produto.
- **`MenuCards`**: Cards com estatísticas básicas do menu (total de produtos, ativos, em destaque e preço médio).
- **`ProductsMenuFilters`**: Filtros para busca e seleção de categorias com alternância de visualização em grade ou lista.
- **`CategoriesFilter`**: Área para gerenciamento e busca de categorias com botão para nova categoria.
- **`TabMenu`**: Controle de abas para alternar entre produtos e categorias.
- **`MenuEmptyState`**: Componente exibido quando não há produtos ou categorias para mostrar.
- **`CardInfo`**: Card informativo reutilizável para exibir dados com ícones e cores.
- **`CategoryDropdown`**: Dropdown customizado para seleção de categorias.
- **`SearchInput`**: Campo de busca estilizado com ícone e botão de limpar.

## Tela da funcionalidade

### Desktop

<img width="1851" height="932" alt="image" src="https://github.com/user-attachments/assets/bf0b43c6-7a17-44d7-950b-4f06c562f6c0" />

### Mobile
<img width="390" height="850" alt="image" src="https://github.com/user-attachments/assets/bc39617b-7829-4cb7-9ef6-995b2f76655c" />
<img width="390" height="850" alt="image" src="https://github.com/user-attachments/assets/db11ffe5-dbcf-49b1-9fa3-29d51a519460" />
<img width="582" height="836" alt="image" src="https://github.com/user-attachments/assets/d7db1d15-4c54-466b-8b89-ce6834f6495b" />

## Observações

- Dados estáticos usados para o layout e estilo.
- Navegação ainda não está implementada (botões e links sem funcionalidade).
- Backend e integração dinâmica serão feitas em próximas etapas.
