### PR TITLE
Configuração de Capybara e testes de system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,23 @@ WORKDIR /app
 RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
   && apt-get update -y \
   && apt-get install -y nodejs \
-  && npm install -g yarn
+  && npm install -g yarn \
+  && apt-get install -y \
+    chromium \
+    chromium-driver \
+    fonts-liberation \
+    libnss3 \
+    libx11-xcb1 \
+    libxcomposite1 \
+    libxcursor1 \
+    libxdamage1 \
+    libxi6 \
+    libxtst6 \
+    xdg-utils \
+    wget \
+    unzip \
+    --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY Gemfile Gemfile.lock ./
 RUN bundle install

--- a/Gemfile
+++ b/Gemfile
@@ -66,5 +66,5 @@ end
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
-  gem "selenium-webdriver"
+  gem "selenium-webdriver", ">= 4.8.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -418,7 +418,7 @@ DEPENDENCIES
   rails (~> 8.0.2)
   rspec-rails (~> 8.0.0)
   rubocop-rails-omakase
-  selenium-webdriver
+  selenium-webdriver (>= 4.8.0)
   solid_cable
   solid_cache
   solid_queue

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
       - "3000:3000"
     volumes:
       - .:/app
-      - bundle:/usr/local/bundle
     working_dir: /app
     entrypoint: ./entrypoint.sh
     command: "rails s -b 0.0.0.0"
@@ -44,5 +43,4 @@ services:
       - "1080:1080"
 
 volumes:
-  bundle:
   pgdata:

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,17 +2,40 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 abort("The Rails environment is running in production mode!") if Rails.env.production?
+require 'capybara/rspec'
 require 'rspec/rails'
+require 'securerandom'
+
+Capybara.register_driver :selenium_chrome_headless do |app|
+  chrome_options = Selenium::WebDriver::Chrome::Options.new.tap do |opts|
+    opts.add_argument('--headless')
+    opts.add_argument('--no-sandbox')
+    opts.add_argument('--disable-dev-shm-usage')
+    opts.add_argument("--user-data-dir=/tmp/test-profile-#{SecureRandom.uuid}")
+  end
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: chrome_options)
+end
 
 begin
   ActiveRecord::Migration.maintain_test_schema!
 rescue ActiveRecord::PendingMigrationError => e
   abort e.to_s.strip
 end
+
 RSpec.configure do |config|
   config.fixture_paths = [
     Rails.root.join('spec/fixtures')
   ]
+
+  config.infer_spec_type_from_file_location!
+
+  config.before(:each, type: :system) do
+    driven_by :selenium_chrome_headless
+  end
+
+  config.include Warden::Test::Helpers
+  config.after(:each) { Warden.test_reset! }
 
   config.include Rails.application.routes.url_helpers
   config.include Devise::Test::IntegrationHelpers, type: :request

--- a/spec/system/user_visit_home_page_spec.rb
+++ b/spec/system/user_visit_home_page_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe "User visits home page", js: true do
+  it "needs to be logged in" do
+    visit root_path
+
+    expect(page).to have_current_path(new_restaurant_user_session_path)
+    expect(page).to have_content("Para continuar, efetue login ou registre-se")
+    expect(page).to have_content("Entrar")
+  end
+
+  it "successfully" do
+    restaurant_user = create(:restaurant_user)
+    login_as(restaurant_user, scope: :restaurant_user)
+
+    visit root_path
+    expect(page).to have_content("Dashboard")
+    expect(page).to have_content("Bem-vindo de volta, Hamburgueria Top")
+  end
+end


### PR DESCRIPTION
Fecha a issue #52 

## Descrição

Este PR adiciona a configuração do Capybara com Selenium e Chrome headless para os testes de system no projeto. Também inclui um exemplo de teste de system para a página inicial.

## Alterações

- Atualização do `Dockerfile` para instalar o Chrome e dependências necessárias para testes headless.
- Atualização do `Gemfile` e `Gemfile.lock` para garantir versão compatível do `selenium-webdriver` (>= 4.8.0).
- Configuração do Capybara em `spec/rails_helper.rb` usando `:selenium_chrome_headless`.
- Criação do teste de system `spec/system/user_visit_home_page_spec.rb`.
- Adição do Warden::Test::Helpers para utilizar o método para criação de sessão durante testes.

## Benefícios

- Permite rodar testes de system de forma confiável em ambiente de CI e local.
- Evita problemas de versão de WebDriver e Chrome.
- Estrutura preparada para novos testes de interface.

## Notas

- Capybara está configurado para criar perfis temporários únicos para cada execução de teste, evitando conflitos de cache.
- Nenhuma alteração funcional no código da aplicação foi realizada.
