### PR TITLE
Implementar fluxo de cadastro de restaurante (new/create)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@
 
 node_modules
 *.local
+
+/coverage

--- a/Gemfile
+++ b/Gemfile
@@ -67,5 +67,6 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "launchy"
+  gem "simplecov", require: false
   gem "selenium-webdriver", ">= 4.8.0"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,6 @@ end
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
-  gem "selenium-webdriver", ">= 4.8.0"
   gem "launchy"
+  gem "selenium-webdriver", ">= 4.8.0"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -67,4 +67,5 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver", ">= 4.8.0"
+  gem "launchy"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,7 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.6.2)
+    docile (1.4.1)
     dotenv (3.1.8)
     drb (2.2.3)
     ed25519 (1.4.0)
@@ -336,6 +337,12 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     solid_cable (3.0.11)
       actioncable (>= 7.2)
       activejob (>= 7.2)
@@ -426,6 +433,7 @@ DEPENDENCIES
   rspec-rails (~> 8.0.0)
   rubocop-rails-omakase
   selenium-webdriver (>= 4.8.0)
+  simplecov
   solid_cable
   solid_cache
   solid_queue

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
@@ -157,6 +159,10 @@ GEM
       thor (~> 1.3)
       zeitwerk (>= 2.6.18, < 3.0)
     language_server-protocol (3.17.0.5)
+    launchy (3.1.0)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.24.1)
@@ -412,6 +418,7 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails (~> 1.3)
   kamal
+  launchy
   pg (~> 1.1)
   propshaft
   puma (>= 5.0)

--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -1,0 +1,2 @@
+class Api::V1::ApplicationController < ActionController::API
+end

--- a/app/controllers/api/v1/restaurants_controller.rb
+++ b/app/controllers/api/v1/restaurants_controller.rb
@@ -1,0 +1,17 @@
+class Api::V1::RestaurantsController < Api::V1::ApplicationController
+  def create
+    restaurant = current_restaurant_user.build_restaurant(restaurant_params)
+
+    if restaurant.save
+      render json: { message: I18n.t("api.v1.restaurants.create.success"), restaurant: restaurant }, status: :created
+    else
+      render json: { status: :unprocessable_entity, message: restaurant.errors.full_messages.join(", ") }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def restaurant_params
+    params.require(:restaurant).permit(:name, :culinary_style, :description, :image, :phone, :address)
+  end
+end

--- a/app/controllers/api/v1/restaurants_controller.rb
+++ b/app/controllers/api/v1/restaurants_controller.rb
@@ -1,17 +1,24 @@
 class Api::V1::RestaurantsController < Api::V1::ApplicationController
   def create
-    restaurant = current_restaurant_user.build_restaurant(restaurant_params)
+    restaurant = Restaurant.new(restaurant_params)
 
     if restaurant.save
       render json: { message: I18n.t("api.v1.restaurants.create.success"), restaurant: restaurant }, status: :created
     else
-      render json: { status: :unprocessable_entity, message: restaurant.errors.full_messages.join(", ") }, status: :unprocessable_entity
+      render json: { status: :unprocessable_entity, errors: restaurant.errors.full_messages.join(", ") }, status: :unprocessable_entity
     end
   end
 
   private
 
   def restaurant_params
-    params.require(:restaurant).permit(:name, :culinary_style, :description, :image, :phone, :address)
+    params.require(:restaurant).permit(
+      :name,
+      :culinary_style,
+      :description,
+      :image,
+      :phone,
+      :address
+    ).merge(restaurant_user: current_restaurant_user)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,15 @@
 class ApplicationController < ActionController::Base
   allow_browser versions: :modern
   before_action :authenticate_restaurant_user!
+  before_action :restaurant_user_signed_in?
+
+  private
+
+  def restaurant_user_signed_in?
+    if current_restaurant_user && current_restaurant_user.restaurant.nil?
+      unless flash[:alert].present? || flash[:notice].present?
+        redirect_to new_restaurant_path, alert: I18n.t("alerts.restaurant.must_register")
+      end
+    end
+  end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,3 +1,5 @@
 class DashboardController < ApplicationController
-  def index; end
+  def index
+    @restaurant = current_restaurant_user.restaurant
+  end
 end

--- a/app/controllers/flash_controller.rb
+++ b/app/controllers/flash_controller.rb
@@ -1,0 +1,9 @@
+class FlashController < ApplicationController
+  skip_before_action :restaurant_user_signed_in?
+
+  def redirect
+    flash[:notice] = params[:notice] if params[:notice].present?
+    flash[:alert]  = params[:alert] if params[:alert].present?
+    redirect_to params[:path] || root_path
+  end
+end

--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -5,7 +5,8 @@ class RestaurantsController < ApplicationController
   def edit; end
 
   def new
-    redirect_to edit_restaurant_path(@restaurant) if @restaurant.present?
+    redirect_to edit_restaurant_path(@restaurant),
+                alert: I18n.t("restaurants.new.you_already_have") if @restaurant.present?
   end
 
   private

--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -1,3 +1,16 @@
 class RestaurantsController < ApplicationController
+  skip_before_action :restaurant_user_signed_in?, only: %i[new]
+  before_action :set_restaurant, only: %i[edit new]
+
   def edit; end
+
+  def new
+    redirect_to edit_restaurant_path(@restaurant) if @restaurant.present?
+  end
+
+  private
+
+  def set_restaurant
+    @restaurant = current_restaurant_user.restaurant
+  end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -14,7 +14,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const dashboardEl = document.getElementById('dashboard-widget')
   if (dashboardEl) {
-    createApp(Dashboard).mount(dashboardEl)
+    const restaurantData = JSON.parse(dashboardEl.dataset.restaurant);
+
+    createApp(Dashboard, { restaurantData: restaurantData }).mount(dashboardEl)
   }
 
   const menuEl = document.getElementById('menu-widget')
@@ -29,6 +31,21 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const editRestaurant = document.getElementById('edit-restaurant')
   if (editRestaurant) {
-    createApp(RestaurantForm).mount(editRestaurant)
+    const restaurantData = JSON.parse(editRestaurant.dataset.restaurant);
+    const dataEmail = editRestaurant.dataset.email;
+
+    console.log("restaurantData do usuário logado: ", restaurantData);
+
+    createApp(RestaurantForm, { initialData: restaurantData, currentEmail: dataEmail}).mount(editRestaurant)
+  }
+
+  const newRestaurant = document.getElementById('new-restaurant')
+  if (newRestaurant) {
+    const restaurantData = ''
+    const dataEmail = newRestaurant.dataset.email;
+
+    console.log("Email do usuário logado: ", dataEmail);
+
+    createApp(RestaurantForm, { initialData: restaurantData, currentEmail: dataEmail}).mount(newRestaurant)
   }
 })

--- a/app/javascript/components/dashboard/Dashboard.vue
+++ b/app/javascript/components/dashboard/Dashboard.vue
@@ -12,7 +12,7 @@
           <RecentOrders />
         </div>
         <div class="dashboard-right">
-          <RestaurantInfo />
+          <RestaurantInfo :restaurantData="restaurantData" />
           <PerformanceChart
             :metrics="[
               { label: 'Visualizações', total: 1000, value: 234, suffix: '' },
@@ -31,6 +31,10 @@ import OverviewStats from './OverviewStats.vue';
 import RecentOrders from './RecentOrders.vue';
 import RestaurantInfo from './RestaurantInfo.vue';
 import PerformanceChart from './PerformanceChart.vue';
+
+defineProps({
+  restaurantData: Object
+})
 </script>
 
 <style scoped>

--- a/app/javascript/components/dashboard/RestaurantInfo.vue
+++ b/app/javascript/components/dashboard/RestaurantInfo.vue
@@ -4,7 +4,7 @@
       <h2>Informações do restaurante</h2>
       <AppButton
         text="Editar"
-        @click="navigateTo('/restaurants/edit')"
+        @click="navigateTo(`/restaurants/${restaurantData.id}/edit`)"
         iconLeft="lucide-pen-line"
         class="btn-edit"
       />
@@ -35,6 +35,10 @@
 <script setup>
 import AppButton from '../ui/AppButton.vue'
 import { navigateTo } from '../../utils/navigation'
+
+defineProps({
+  restaurantData: Object
+})
 
 const informations = [
   { label: 'Avaliação', value: '4.8' },

--- a/app/javascript/components/restaurant/RestaurantBasicInputs.vue
+++ b/app/javascript/components/restaurant/RestaurantBasicInputs.vue
@@ -34,8 +34,8 @@
             { label: 'Lanches', value: 'snacks' },
             { label: 'Churrasco', value: 'barbecue' },
             { label: 'Frutos do Mar', value: 'seafood' },
-            { label: 'Cafeteria', value: 'coffee-shop' },
-            { label: 'Sorveteria', value: 'ice-cream' }
+            { label: 'Cafeteria', value: 'coffee_shop' },
+            { label: 'Sorveteria', value: 'ice_cream' }
           ]"
           placeholder="Tipo de Culinária"
           label="Tipo de Culinária"
@@ -58,16 +58,16 @@
         id="restaurant-image"
         label="Imagem"
         placeholder="Imagem"
-        v-model="restaurant.image_url"
+        v-model="restaurant.image"
         required
-        :externalError="restaurantErrors?.image_url"
+        :externalError="restaurantErrors?.image"
       />
 
       <div class="restaurant-image">
         <img
-          v-if="restaurant.image_url"
+          v-if="restaurant.image"
           alt="Restaurant"
-          :src="restaurant.image_url"
+          :src="restaurant.image"
         />
       </div>
     </div>

--- a/app/javascript/components/restaurant/RestaurantForm.vue
+++ b/app/javascript/components/restaurant/RestaurantForm.vue
@@ -50,7 +50,7 @@ const restaurant = reactive({
   name: initialData?.name || null,
   culinary_style: initialData?.culinary_style || null,
   description: initialData?.description || null,
-  image_url: initialData?.image_url || null,
+  image: initialData?.image || null,
   phone: initialData?.phone || null,
   email: currentEmail || null,
   address: initialData?.address || null,
@@ -63,7 +63,7 @@ function submit() {
     name: restaurant.name,
     culinary_style: restaurant.culinary_style,
     description: restaurant.description,
-    image_url: restaurant.image_url,
+    image: restaurant.image,
     phone: restaurant.phone,
     address: restaurant.address,
   };

--- a/app/javascript/components/restaurant/RestaurantForm.vue
+++ b/app/javascript/components/restaurant/RestaurantForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <RestaurantFormOverview />
+  <RestaurantFormOverview :restaurantExists="initialData !== ''" />
 
   <div class="restaurant-form">
     <div class="form-container">
@@ -10,6 +10,7 @@
 
       <div class="form-actions">
         <AppButton
+          v-if="initialData.length > 0"
           class="cancel"
           text="Cancelar"
           @click="navigateTo('/')"
@@ -34,15 +35,25 @@ import RestaurantBasicInputs from './RestaurantBasicInputs.vue';
 import AppButton from '../ui/AppButton.vue';
 import { useRestaurantValidator } from '../../composables/useRestaurantValidator';
 import { navigateTo } from '../../utils/navigation';
+import { apiPost } from '../../utils/apiHelper'
+
+
+const props = defineProps ({
+  initialData: Object,
+  currentEmail: String
+})
+
+const initialData = props.initialData
+const currentEmail = props.currentEmail
 
 const restaurant = reactive({
-  name: null,
-  culinary_style: null,
-  description: null,
-  image_url: null,
-  phone: null,
-  email: "email@email.com",
-  address: null,
+  name: initialData?.name || null,
+  culinary_style: initialData?.culinary_style || null,
+  description: initialData?.description || null,
+  image_url: initialData?.image_url || null,
+  phone: initialData?.phone || null,
+  email: currentEmail || null,
+  address: initialData?.address || null,
 });
 
 const { errors: restaurantErrors, isValid: isRestaurantValid } = useRestaurantValidator(restaurant);
@@ -51,14 +62,15 @@ function submit() {
   const payload = {
     name: restaurant.name,
     culinary_style: restaurant.culinary_style,
-    description: null,
-    image_url: null,
-    phone: null,
-    email: "email@email.com",
-    address: null,
+    description: restaurant.description,
+    image_url: restaurant.image_url,
+    phone: restaurant.phone,
+    address: restaurant.address,
   };
 
   console.log('JSON Final para envio:', JSON.stringify(payload, null, 2));
+
+  apiPost('/api/v1/restaurants', payload, 'Restaurante criado com sucesso!')
 }
 </script>
 

--- a/app/javascript/components/restaurant/RestaurantFormOverview.vue
+++ b/app/javascript/components/restaurant/RestaurantFormOverview.vue
@@ -5,7 +5,12 @@
     icon="lucide-store"
   >
     <template #actions>
-      <AppButton text="Voltar a tela inicial" iconLeft="ri:arrow-left-line" @click="navigateTo('/')"/>
+      <AppButton 
+        v-if="restaurantExists"
+        text="Voltar a tela inicial"
+        iconLeft="ri:arrow-left-line"
+        @click="navigateTo('/')"
+      />
     </template>
   </MenuHeader>
 </template>
@@ -14,6 +19,10 @@
 import AppButton from '../ui/AppButton.vue';
 import MenuHeader from '../ui/MenuHeader.vue';
 import { navigateTo } from '../../utils/navigation';
+
+defineProps({
+  restaurantExists: Boolean
+});
 </script>
 
 <style scoped>

--- a/app/javascript/composables/useRestaurantValidator.js
+++ b/app/javascript/composables/useRestaurantValidator.js
@@ -5,7 +5,7 @@ export function useRestaurantValidator(restaurant) {
     name: null,
     culinary_style: null,
     description: null,
-    image_url: null,
+    image: null,
     phone: null,
     email: null,
     address: null,
@@ -24,7 +24,7 @@ export function useRestaurantValidator(restaurant) {
   }
 
   function validateImageUrl() {
-    return !restaurant.image_url?.trim() ? 'URL da imagem é obrigatória' : null
+    return !restaurant.image?.trim() ? 'URL da imagem é obrigatória' : null
   }
 
   function validatePhone() {
@@ -39,7 +39,7 @@ export function useRestaurantValidator(restaurant) {
     errors.name = validateName()
     errors.culinary_style = validateCulinaryStyle()
     errors.description = validateDescription()
-    errors.image_url = validateImageUrl()
+    errors.image = validateImageUrl()
     errors.phone = validatePhone()
     errors.email = validateEmail()
   })

--- a/app/javascript/utils/apiHelper.js
+++ b/app/javascript/utils/apiHelper.js
@@ -1,0 +1,17 @@
+import axios from 'axios'
+import { navigateTo } from './navigation'
+
+export async function apiPost(endpoint, payload, successMessage = 'Operação realizada com sucesso!') {
+  try {
+    const { data } = await axios.post(endpoint, payload, {
+      headers: { 'Content-Type': 'application/json' }
+    })
+    const msg = data?.message || successMessage
+    navigateTo(`/flash?path=${encodeURIComponent('/')}&notice=${encodeURIComponent(msg)}`)
+    return data
+  } catch (error) {
+    const msg = error.response?.data?.message || 'Erro desconhecido'
+    navigateTo(`/flash?path=${encodeURIComponent(window.location.pathname)}&alert=${encodeURIComponent(msg)}`)
+    throw error
+  }
+}

--- a/app/javascript/utils/apiHelper.js
+++ b/app/javascript/utils/apiHelper.js
@@ -10,7 +10,7 @@ export async function apiPost(endpoint, payload, successMessage = 'Operação re
     navigateTo(`/flash?path=${encodeURIComponent('/')}&notice=${encodeURIComponent(msg)}`)
     return data
   } catch (error) {
-    const msg = error.response?.data?.message || 'Erro desconhecido'
+    const msg = error.response?.data?.errors || 'Erro desconhecido'
     navigateTo(`/flash?path=${encodeURIComponent(window.location.pathname)}&alert=${encodeURIComponent(msg)}`)
     throw error
   }

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -1,3 +1,10 @@
 class Restaurant < ApplicationRecord
   belongs_to :restaurant_user
+
+  validates :name, :culinary_style, :description, :image, :phone, presence: true
+  validates :restaurant_user_id, uniqueness: true
+
+  enum :culinary_style, { acai: 0, brazilian: 1, italian: 2, japanese: 3, mexican: 4,
+                        burgers: 5, pizza: 6, healthy: 7, vegetarian: 8, sweets: 9,
+                        snacks: 10, barbecue: 11, seafood: 12, coffee_shop: 13, ice_cream: 14 }
 end

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -1,0 +1,3 @@
+class Restaurant < ApplicationRecord
+  belongs_to :restaurant_user
+end

--- a/app/models/restaurant_user.rb
+++ b/app/models/restaurant_user.rb
@@ -3,4 +3,6 @@ class RestaurantUser < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_one :restaurant, dependent: :destroy
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,1 +1,4 @@
-<div id="dashboard-widget"></div>
+<div
+  id="dashboard-widget"%
+  data-restaurant="<%= @restaurant.to_json %>"
+></div>

--- a/app/views/restaurants/edit.html.erb
+++ b/app/views/restaurants/edit.html.erb
@@ -1,1 +1,5 @@
-<div id="edit-restaurant"></div>
+<div
+  id="edit-restaurant"
+  data-restaurant="<%= @restaurant.to_json %>"
+  data-email="<%= current_restaurant_user.email %>"
+></div>

--- a/app/views/restaurants/new.html.erb
+++ b/app/views/restaurants/new.html.erb
@@ -1,0 +1,4 @@
+<div
+  id="new-restaurant"
+  data-email="<%= current_restaurant_user.email %>"
+></div>

--- a/config/locales/api/v1/restaurants/create.pt-BR.yml
+++ b/config/locales/api/v1/restaurants/create.pt-BR.yml
@@ -1,0 +1,7 @@
+pt-BR:
+  api:
+    v1:
+      restaurants:
+        create:
+          success: "Restaurante criado com sucesso!"
+          error: "Erro ao criar restaurante"

--- a/config/locales/application.pt-BR.yml
+++ b/config/locales/application.pt-BR.yml
@@ -1,0 +1,4 @@
+pt-BR:
+  alerts:
+    restaurant:
+      must_register: "Cadastre seu restaurante para continuar"

--- a/config/locales/controllers/restaurant.pt-BR.yml
+++ b/config/locales/controllers/restaurant.pt-BR.yml
@@ -1,0 +1,4 @@
+pt-BR:
+  restaurants:
+    new:
+      you_already_have: "Você já possui um restaurante cadastrado"

--- a/config/locales/models/restaurant.pt-BR.yml
+++ b/config/locales/models/restaurant.pt-BR.yml
@@ -1,0 +1,14 @@
+pt-BR:
+  activerecord:
+    models:
+      restaurant: Restaurante
+    attributes:
+      restaurant:
+        name: "Nome"
+        culinary_style: "Tipo de Culinária"
+        description: "Descrição"
+        image: "Imagem"
+        address: "Endereço"
+        phone: "Telefone"
+        restaurant_user: "Usuário Restaurante"
+        restaurant_user_id: "Usuário Restaurante"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,9 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :restaurants, only: %i[create update ]
+      resources :restaurants, only: %i[create update]
     end
   end
+
+  get "/flash", to: "flash#redirect"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,12 @@ Rails.application.routes.draw do
 
   get "/menu", to: "menus#show"
   get "/products/new", to: "products#new"
-  get "/restaurants/edit", to: "restaurants#edit"
+
+  resources :restaurants, only: %i[new edit]
+
+  namespace :api do
+    namespace :v1 do
+      resources :restaurants, only: %i[create update ]
+    end
+  end
 end

--- a/db/migrate/20250828151334_create_restaurants.rb
+++ b/db/migrate/20250828151334_create_restaurants.rb
@@ -1,0 +1,15 @@
+class CreateRestaurants < ActiveRecord::Migration[8.0]
+  def change
+    create_table :restaurants do |t|
+      t.string :name
+      t.integer :culinary_style
+      t.text :description
+      t.string :image
+      t.string :phone
+      t.string :address
+      t.references :restaurant_user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_12_174224) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_28_151334) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -25,4 +25,19 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_12_174224) do
     t.index ["email"], name: "index_restaurant_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_restaurant_users_on_reset_password_token", unique: true
   end
+
+  create_table "restaurants", force: :cascade do |t|
+    t.string "name"
+    t.integer "culinary_style"
+    t.text "description"
+    t.string "image"
+    t.string "phone"
+    t.string "address"
+    t.bigint "restaurant_user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["restaurant_user_id"], name: "index_restaurants_on_restaurant_user_id"
+  end
+
+  add_foreign_key "restaurants", "restaurant_users"
 end

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.6",
+    "axios": "^1.11.0",
     "esbuild-plugin-vue3": "^0.4.2",
     "vue": "^3.2.0"
   },

--- a/spec/factories/restaurants.rb
+++ b/spec/factories/restaurants.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :restaurant do
+    name { "MyString" }
+    culinary_style { 1 }
+    description { "MyText" }
+    image { "MyString" }
+    phone { "MyString" }
+    address { "MyString" }
+    restaurant_user { nil }
+  end
+end

--- a/spec/models/restaurant_spec.rb
+++ b/spec/models/restaurant_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Restaurant, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/restaurant_spec.rb
+++ b/spec/models/restaurant_spec.rb
@@ -1,5 +1,45 @@
 require 'rails_helper'
 
 RSpec.describe Restaurant, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:user) { create(:restaurant_user) }
+
+  context '.valid' do
+    it 'is invalid without a name' do
+      restaurant = Restaurant.new(name: nil)
+      expect(restaurant).not_to be_valid
+      expect(restaurant.errors.full_messages).to include("Nome não pode ficar em branco")
+    end
+
+    it 'is invalid without a culinary_style' do
+      restaurant = Restaurant.new(culinary_style: nil)
+      expect(restaurant).not_to be_valid
+      expect(restaurant.errors.full_messages).to include("Tipo de Culinária não pode ficar em branco")
+    end
+
+    it 'is invalid without a description' do
+      restaurant = Restaurant.new(description: nil)
+      expect(restaurant).not_to be_valid
+      expect(restaurant.errors.full_messages).to include("Descrição não pode ficar em branco")
+    end
+
+    it 'is invalid without a image' do
+      restaurant = Restaurant.new(image: nil)
+      expect(restaurant).not_to be_valid
+      expect(restaurant.errors.full_messages).to include("Imagem não pode ficar em branco")
+    end
+
+    it 'is invalid without a phone' do
+      restaurant = Restaurant.new(phone: nil)
+      expect(restaurant).not_to be_valid
+      expect(restaurant.errors.full_messages).to include("Telefone não pode ficar em branco")
+    end
+
+    it 'enforces uniqueness of restaurant_user_id' do
+      create(:restaurant, restaurant_user: user)
+      duplicate = Restaurant.new(restaurant_user: user)
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors.full_messages).to include("Usuário Restaurante já está em uso")
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,14 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'capybara/rspec'
 require 'rspec/rails'
 require 'securerandom'
+require 'simplecov'
+
+SimpleCov.start 'rails' do
+  add_filter 'channels'
+  add_filter 'mailers'
+  add_filter 'jobs'
+  add_filter 'helpers'
+end
 
 Capybara.register_driver :selenium_chrome_headless do |app|
   chrome_options = Selenium::WebDriver::Chrome::Options.new.tap do |opts|

--- a/spec/requests/api/v1/restaurants/create_restaurant_spec.rb
+++ b/spec/requests/api/v1/restaurants/create_restaurant_spec.rb
@@ -1,0 +1,102 @@
+require 'rails_helper'
+
+describe "POST /api/v1/restaurants" do
+  context "when user is logged in" do
+    it "creates successfully" do
+      user = create(:restaurant_user)
+      restaurant_params = {
+        restaurant: {
+          name: "Testaurant",
+          culinary_style: "italian",
+          description: "A test restaurant",
+          image: 'https://example.com/image.jpg',
+          phone: "123-456-7890",
+          address: "123 Test St"
+        }
+      }
+      login_as user
+
+      post api_v1_restaurants_path, params: restaurant_params
+
+      expect(response).to have_http_status(201)
+      json_response = JSON.parse(response.body)
+      restaurant_response = json_response["restaurant"]
+      expect(restaurant_response["name"]).to eq("Testaurant")
+      expect(restaurant_response["address"]).to eq("123 Test St")
+      expect(restaurant_response["phone"]).to eq("123-456-7890")
+      expect(restaurant_response["description"]).to eq("A test restaurant")
+      expect(restaurant_response["restaurant_user_id"]).to eq(user.id)
+    end
+
+    it "returns error if required fields are blank" do
+      user = create(:restaurant_user)
+      restaurant_params = {
+        restaurant: {
+          name: "",
+          culinary_style: "",
+          description: "",
+          image: '',
+          phone: "",
+          address: ""
+        }
+      }
+      login_as user
+
+      post api_v1_restaurants_path, params: restaurant_params
+
+      expect(response).to have_http_status(422)
+      json_response = JSON.parse(response.body)
+      expect(json_response["errors"]).to include("Nome não pode ficar em branco")
+      expect(json_response["errors"]).to include("Tipo de Culinária não pode ficar em branco")
+      expect(json_response["errors"]).to include("Descrição não pode ficar em branco")
+      expect(json_response["errors"]).to include("Imagem não pode ficar em branco")
+      expect(json_response["errors"]).to include("Telefone não pode ficar em branco")
+      expect(json_response["errors"]).not_to include("Endereço não pode ficar em branco")
+    end
+  end
+
+  context "when user is not logged in" do
+    it "returns unauthorized" do
+      restaurant_params = {
+        restaurant: {
+          name: "Testaurant",
+          culinary_style: "italian",
+          description: "A test restaurant",
+          image: 'https://example.com/image.jpg',
+          phone: "123-456-7890",
+          address: "123 Test St"
+        }
+      }
+
+      post api_v1_restaurants_path, params: restaurant_params
+
+      json_response = JSON.parse(response.body)
+      expect(response).to have_http_status(422)
+      expect(json_response["errors"]).to eq("Usuário Restaurante é obrigatório(a)")
+    end
+  end
+
+  context "when it cannot create" do
+    it "when restaurant_user already has a restaurant" do
+      user = create(:restaurant_user)
+      create(:restaurant, restaurant_user: user)
+      restaurant_params = {
+        restaurant: {
+          name: "Testaurant",
+          culinary_style: "italian",
+          description: "A test restaurant",
+          image: 'https://example.com/image.jpg',
+          phone: "123-456-7890",
+          address: "123 Test St"
+        }
+      }
+      login_as user
+
+      post api_v1_restaurants_path, params: restaurant_params
+
+      json_response = JSON.parse(response.body)
+      expect(response).to have_http_status(422)
+      expect(json_response["errors"]).to include("Usuário Restaurante já está em uso")
+    end
+  end
+end

--- a/spec/requests/authorization/root_authorization_spec.rb
+++ b/spec/requests/authorization/root_authorization_spec.rb
@@ -11,10 +11,13 @@ RSpec.describe "Authorization - Root", type: :request do
   context "when user is authenticated" do
     let(:user) { create(:restaurant_user) }
 
-    before { sign_in user }
+    before { login_as user, scope: :restaurant_user }
 
     it "allow access" do
+      user.create_restaurant
+
       get root_path
+
       expect(response).to have_http_status(:ok)
     end
   end

--- a/spec/requests/flash_container_spec.rb
+++ b/spec/requests/flash_container_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe FlashController, type: :request do
+  let(:restaurant_user) { create(:restaurant_user) }
+
+  before do
+    login_as(restaurant_user, scope: :restaurant_user)
+  end
+
+  describe "GET /flash" do
+    let(:path) { "/" }
+
+    context "when notice and alert params are present" do
+      it "sets flash notice and alert and redirects to the given path" do
+        get "/flash", params: { path: path, notice: "Success!", alert: "Something went wrong" }
+
+        expect(flash[:notice]).to eq("Success!")
+        expect(flash[:alert]).to eq("Something went wrong")
+        expect(response).to redirect_to(path)
+      end
+    end
+
+    context "when only notice param is present" do
+      it "sets only flash notice and redirects" do
+        get "/flash", params: { path: path, notice: "Success!" }
+
+        expect(flash[:notice]).to eq("Success!")
+        expect(flash[:alert]).to be_nil
+        expect(response).to redirect_to(path)
+      end
+    end
+
+    context "when only alert param is present" do
+      it "sets only flash alert and redirects" do
+        get "/flash", params: { path: path, alert: "Something went wrong" }
+
+        expect(flash[:alert]).to eq("Something went wrong")
+        expect(flash[:notice]).to be_nil
+        expect(response).to redirect_to(path)
+      end
+    end
+
+    context "when no path param is given" do
+      it "redirects to root path" do
+        get "/flash"
+
+        expect(flash[:alert]).to be_nil
+        expect(flash[:notice]).to be_nil
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end

--- a/spec/requests/restaurants/user_access_restaurant_new_spec.rb
+++ b/spec/requests/restaurants/user_access_restaurant_new_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe 'User access new form path' do
+  context 'GET /restaurants/new' do
+    it 'successfully' do
+      user = create(:restaurant_user)
+      login_as user, scope: :restaurant_user
+
+      get new_restaurant_path
+
+      expect(response).to have_http_status(200)
+    end
+
+    context 'cannot access' do
+      it 'when not logged in' do
+        get new_restaurant_path
+        expect(response).to have_http_status(302)
+        expect(response).to redirect_to(new_restaurant_user_session_path)
+        expect(flash[:alert]).to match(/Para continuar, efetue login ou registre-se./)
+      end
+
+      it 'when restaurant_user already has a restaurant' do
+        user = create(:restaurant_user)
+        create(:restaurant, restaurant_user: user)
+        login_as user, scope: :restaurant_user
+
+        get new_restaurant_path
+
+        expect(response).to have_http_status(302)
+        expect(response).to redirect_to(edit_restaurant_path user.restaurant)
+        expect(flash[:alert]).to match(/Você já possui um restaurante cadastrado/)
+      end
+    end
+  end
+end

--- a/spec/system/restaurants/user_create_restaurant_spec.rb
+++ b/spec/system/restaurants/user_create_restaurant_spec.rb
@@ -68,8 +68,15 @@ describe 'User creates a restaurant' do
 
       expect(page).to have_content('Restaurante criado com sucesso')
       expect(page).to have_current_path(root_path)
-      expect(restaurant_user.reload.restaurant).to eq Restaurant.last
       expect(Restaurant.count).to eq 1
+      restaurant = Restaurant.last
+      expect(restaurant_user.reload.restaurant).to eq restaurant
+      expect(restaurant.name).to eq 'Restaurante Legal'
+      expect(restaurant.culinary_style).to eq 'brazilian'
+      expect(restaurant.description).to eq 'Comida boa'
+      expect(restaurant.image).to eq 'http://www.imagem.com/imagem.png'
+      expect(restaurant.phone).to eq '(11) 99999-9999'
+      expect(restaurant.address).to eq 'Av. Brasil, 1000'
     end
 
     it 'and see errors in all required fields after touched' do

--- a/spec/system/restaurants/user_create_restaurant_spec.rb
+++ b/spec/system/restaurants/user_create_restaurant_spec.rb
@@ -1,0 +1,102 @@
+require 'rails_helper'
+
+describe 'User creates a restaurant' do
+  context 'when logged in' do
+    it 'shows the restaurant registration form' do
+      restaurant_user = create(:restaurant_user)
+      login_as(restaurant_user, scope: :restaurant_user)
+
+      visit root_path
+
+      expect(page).to have_content('Informações Básicas')
+      expect(page).to have_content('Preencha as informações básicas do seu restaurante')
+      expect(page).to have_current_path(new_restaurant_path)
+      expect(page).to have_content('Cadastre seu restaurante para continuar')
+      expect(page).not_to have_button('Voltar a tela inicial')
+      expect(page).to have_field('Nome')
+      expect(page).to have_field('Tipo de Culinária')
+      expect(page).to have_field('Descrição')
+      expect(page).to have_field('Imagem')
+      expect(page).to have_field('Telefone')
+      expect(page).to have_field('Endereço Completo')
+      expect(page).not_to have_button('Cancelar')
+      expect(page).not_to have_button('Salvar')
+    end
+
+    it 'and sees an error message if something goes wrong on the server' do
+      restaurant_user = create(:restaurant_user)
+      login_as(restaurant_user, scope: :restaurant_user)
+
+      allow_any_instance_of(Restaurant).to receive(:save).and_return(false)
+      allow_any_instance_of(Restaurant).to receive_message_chain(:errors, :full_messages)
+                                       .and_return([ "Erro interno no servidor" ])
+
+      visit root_path
+
+      fill_in 'Nome', with: 'Restaurante Bugado'
+      fill_in 'Tipo de Culinária', with: 'Italiana'
+      within '.dropdown-menu' do
+        find('.dropdown-item', text: 'Italiana').click
+      end
+      fill_in 'Descrição', with: 'Esse restaurante vai falhar'
+      fill_in 'Imagem', with: 'http://www.imagem.com/imagem.png'
+      fill_in 'Telefone', with: '(11) 99999-9999'
+      fill_in 'Endereço Completo', with: 'Av. Paulista, 2000'
+
+      click_on 'Salvar'
+
+      expect(page).to have_content('Erro interno no servidor')
+      expect(page).to have_current_path(new_restaurant_path)
+    end
+
+    it 'successfully' do
+      restaurant_user = create(:restaurant_user)
+      login_as(restaurant_user, scope: :restaurant_user)
+
+      visit root_path
+
+      fill_in 'Nome', with: 'Restaurante Legal'
+      fill_in 'Tipo de Culinária', with: 'Brasi'
+      within '.dropdown-menu' do
+        find('.dropdown-item', text: 'Brasileira').click
+      end
+      fill_in 'Descrição', with: 'Comida boa'
+      fill_in 'Imagem', with: 'http://www.imagem.com/imagem.png'
+      fill_in 'Telefone', with: '(11) 99999-9999'
+      fill_in 'Endereço Completo', with: 'Av. Brasil, 1000'
+      click_on 'Salvar'
+
+      expect(page).to have_content('Restaurante criado com sucesso')
+      expect(page).to have_current_path(root_path)
+      expect(restaurant_user.reload.restaurant).to eq Restaurant.last
+      expect(Restaurant.count).to eq 1
+    end
+
+    it 'and see errors in all required fields after touched' do
+      restaurant_user = create(:restaurant_user)
+      login_as(restaurant_user, scope: :restaurant_user)
+
+      visit root_path
+      fill_in 'Nome', with: ''
+      fill_in 'Tipo de Culinária', with: ''
+      within '.dropdown-menu' do
+        find('.dropdown-item', text: 'Tipo de Culinária').click
+      end
+      fill_in 'Descrição', with: ''
+      fill_in 'Imagem', with: ''
+      fill_in 'Telefone', with: ''
+      fill_in 'Endereço', with: ''
+      fill_in 'Telefone', with: ''
+
+      expect(page).not_to have_button('Cancelar')
+      expect(page).not_to have_button('Salvar')
+      expect(page).to have_content('Cadastre seu restaurante para continuar')
+      expect(page).to have_content('Nome do restaurante é obrigatório')
+      expect(page).to have_content('Estilo culinário é obrigatório')
+      expect(page).to have_content('Descrição é obrigatória')
+      expect(page).to have_content('URL da imagem é obrigatória')
+      expect(page).to have_content('Telefone é obrigatório')
+      expect(page).not_to have_content('Endereço é obrigatório')
+    end
+  end
+end

--- a/spec/system/user_visit_home_page_spec.rb
+++ b/spec/system/user_visit_home_page_spec.rb
@@ -12,6 +12,7 @@ describe "User visits home page", js: true do
   it "successfully" do
     restaurant_user = create(:restaurant_user)
     login_as(restaurant_user, scope: :restaurant_user)
+    restaurant_user.create_restaurant(name: "Hamburgueria Top")
 
     visit root_path
     expect(page).to have_content("Dashboard")

--- a/yarn.lock
+++ b/yarn.lock
@@ -264,15 +264,85 @@
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.5.17.tgz#e8b3a41f0be76499882a89e8ed40d86a70fa4b70"
   integrity sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
+axios@^1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.11.0.tgz#c2ec219e35e414c025b2095e8b8280278478fdb6"
+  integrity sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.4"
+    proxy-from-env "^1.1.0"
+
+call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
+  integrity sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==
+  dependencies:
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
+
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 csstype@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
+
+dunder-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
+  integrity sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==
+  dependencies:
+    call-bind-apply-helpers "^1.0.1"
+    es-errors "^1.3.0"
+    gopd "^1.2.0"
+
 entities@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
+
+es-define-property@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.1.tgz#983eb2f9a6724e9303f61addf011c72e09e0b0fa"
+  integrity sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==
+
+es-errors@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
+  integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
+
+es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz#1c4f2c4837327597ce69d2ca190a7fdd172338c1"
+  integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
+  dependencies:
+    es-errors "^1.3.0"
+
+es-set-tostringtag@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
+  integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
+  dependencies:
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.6"
+    has-tostringtag "^1.0.2"
+    hasown "^2.0.2"
 
 esbuild-android-64@0.14.54:
   version "0.14.54"
@@ -446,12 +516,98 @@ estree-walker@^2.0.2:
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
   integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
+follow-redirects@^1.15.6:
+  version "1.15.11"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
+  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
+
+form-data@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
+  integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.2"
+    mime-types "^2.1.12"
+
+function-bind@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
+  integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
+
+get-intrinsic@^1.2.6:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
+  integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    es-define-property "^1.0.1"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.1.1"
+    function-bind "^1.1.2"
+    get-proto "^1.0.1"
+    gopd "^1.2.0"
+    has-symbols "^1.1.0"
+    hasown "^2.0.2"
+    math-intrinsics "^1.1.0"
+
+get-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-proto/-/get-proto-1.0.1.tgz#150b3f2743869ef3e851ec0c49d15b1d14d00ee1"
+  integrity sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==
+  dependencies:
+    dunder-proto "^1.0.1"
+    es-object-atoms "^1.0.0"
+
+gopd@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
+  integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
+
+has-symbols@^1.0.3, has-symbols@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
+  integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
+
+has-tostringtag@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz#2cdc42d40bef2e5b4eeab7c01a73c54ce7ab5abc"
+  integrity sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==
+  dependencies:
+    has-symbols "^1.0.3"
+
+hasown@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
+  integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
+  dependencies:
+    function-bind "^1.1.2"
+
 magic-string@^0.30.17:
   version "0.30.17"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.17.tgz#450a449673d2460e5bbcfba9a61916a1714c7453"
   integrity sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.0"
+
+math-intrinsics@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
+  integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
+
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
 
 nanoid@^3.3.11:
   version "3.3.11"
@@ -471,6 +627,11 @@ postcss@^8.5.6:
     nanoid "^3.3.11"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 source-map-js@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
Esse PR fecha parte da issue #38 

## Descrição
Este PR entrega a primeira parte do cadastro de restaurantes, permitindo que um usuário restaurante crie seu próprio restaurante pela interface web e pela API.

## O que foi feito
- Criação do **modelo `Restaurant`** com validações de presença e unicidade.
- Adicionado **endpoint `POST /api/v1/restaurants`** para cadastro via API.
- Ajustes no **controller web** para impedir múltiplos cadastros por usuário (redireciona para edição caso já exista restaurante).
- Atualização dos **componentes Vue** (`RestaurantForm`, `RestaurantBasicInputs`) para usar o campo `image` e enums de culinária padronizados.
- Inclusão de **mensagens traduzidas** (i18n) para atributos e restrições de acesso.
- Adição de uma rota para adicionar mensagens ao **flash**.
- Adição do `SimpleCov` para gerenciar cobertura de testes.
- Adicionados **tests**:
  - Model specs para validações.
  - Request specs (API e web) cobrindo criação, erros de validação e restrições de acesso.
  - System spec validando persistência completa no fluxo de criação.

## Motivação
Permitir o cadastro de restaurantes de forma segura e consistente, garantindo que:
- Cada usuário restaurante só possa criar **um restaurante**.
- Todos os campos obrigatórios sejam validados.
- A interface e a API estejam sincronizadas com a mesma lógica de negócio.


## Telas da funcionalidade

### Desktop
<img width="1835" height="1011" alt="Captura de tela de 2025-08-29 12-35-38" src="https://github.com/user-attachments/assets/d876892b-ce07-4cbb-ac2f-cbbadef160c4" />
<img width="1835" height="1011" alt="Captura de tela de 2025-08-29 12-36-19" src="https://github.com/user-attachments/assets/c5fa324d-a0e9-4699-b3ab-0aaa3f78bcbe" />

### Mobile
<img width="381" height="664" alt="Captura de tela de 2025-08-29 12-37-07" src="https://github.com/user-attachments/assets/052b0b32-0d0a-412f-846c-8d99af8d7bb0" />


## Observações
PR foca apenas no fluxo **new/create**. Funcionalidades de edição (`edit`) serão entregues em um PR posterior.
