### PR TITLE
Feature: fluxo de edição de restaurante

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ gem "jbuilder"
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"
 
+gem "pundit"
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,6 +232,8 @@ GEM
     public_suffix (6.0.2)
     puma (6.6.0)
       nio4r (~> 2.0)
+    pundit (2.5.0)
+      activesupport (>= 3.0.0)
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.1.16)
@@ -429,6 +431,7 @@ DEPENDENCIES
   pg (~> 1.1)
   propshaft
   puma (>= 5.0)
+  pundit
   rails (~> 8.0.2)
   rspec-rails (~> 8.0.0)
   rubocop-rails-omakase

--- a/app/controllers/api/v1/restaurants_controller.rb
+++ b/app/controllers/api/v1/restaurants_controller.rb
@@ -9,6 +9,16 @@ class Api::V1::RestaurantsController < Api::V1::ApplicationController
     end
   end
 
+  def update
+    restaurant = current_restaurant_user.restaurant
+
+    if restaurant.update(restaurant_params)
+      render json: { message: I18n.t("api.v1.restaurants.update.success"), restaurant: restaurant }, status: :ok
+    else
+      render json: { status: :unprocessable_entity, errors: restaurant.errors.full_messages.join(", ") }, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def restaurant_params

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,24 @@
 class ApplicationController < ActionController::Base
   allow_browser versions: :modern
   before_action :authenticate_restaurant_user!
-  before_action :restaurant_user_signed_in?
+  before_action :restaurant_registered?
+
+  include Pundit::Authorization
+
+  def pundit_user
+    current_restaurant_user
+  end
+
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   private
 
-  def restaurant_user_signed_in?
+  def user_not_authorized
+    flash[:alert] = I18n.t "alerts.pundit.default", default:
+    redirect_to(request.referer || root_path)
+  end
+
+  def restaurant_registered?
     if current_restaurant_user && current_restaurant_user.restaurant.nil?
       unless flash[:alert].present? || flash[:notice].present?
         redirect_to new_restaurant_path, alert: I18n.t("alerts.restaurant.must_register")

--- a/app/controllers/flash_controller.rb
+++ b/app/controllers/flash_controller.rb
@@ -1,5 +1,5 @@
 class FlashController < ApplicationController
-  skip_before_action :restaurant_user_signed_in?
+  skip_before_action :restaurant_registered?
 
   def redirect
     flash[:notice] = params[:notice] if params[:notice].present?

--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -1,17 +1,19 @@
 class RestaurantsController < ApplicationController
-  skip_before_action :restaurant_user_signed_in?, only: %i[new]
-  before_action :set_restaurant, only: %i[edit new]
+  skip_before_action :restaurant_registered?, only: %i[new]
+  before_action :set_restaurant, only: %i[edit]
 
-  def edit; end
+  def edit
+    authorize @restaurant
+  end
 
   def new
-    redirect_to edit_restaurant_path(@restaurant),
-                alert: I18n.t("restaurants.new.you_already_have") if @restaurant.present?
+    @restaurant = Restaurant.new
+    authorize @restaurant
   end
 
   private
 
   def set_restaurant
-    @restaurant = current_restaurant_user.restaurant
+    @restaurant = Restaurant.find(params[:id]) if params[:id]
   end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -34,8 +34,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const restaurantData = JSON.parse(editRestaurant.dataset.restaurant);
     const dataEmail = editRestaurant.dataset.email;
 
-    console.log("restaurantData do usuário logado: ", restaurantData);
-
     createApp(RestaurantForm, { initialData: restaurantData, currentEmail: dataEmail}).mount(editRestaurant)
   }
 
@@ -43,8 +41,6 @@ document.addEventListener('DOMContentLoaded', () => {
   if (newRestaurant) {
     const restaurantData = ''
     const dataEmail = newRestaurant.dataset.email;
-
-    console.log("Email do usuário logado: ", dataEmail);
 
     createApp(RestaurantForm, { initialData: restaurantData, currentEmail: dataEmail}).mount(newRestaurant)
   }

--- a/app/javascript/components/dashboard/Dashboard.vue
+++ b/app/javascript/components/dashboard/Dashboard.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="dashboard-header">
     <h1 class="title">Dashboard</h1>
-    <p class="welcome-msg">Bem-vindo de volta, Hamburgueria Top</p>
+    <p class="welcome-msg">Bem-vindo de volta, {{ restaurantData.name }}</p>
   </div>
   <div class="dashboard">
     <div class="dashboard-container">

--- a/app/javascript/components/restaurant/RestaurantForm.vue
+++ b/app/javascript/components/restaurant/RestaurantForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <RestaurantFormOverview :restaurantExists="initialData !== ''" />
+  <RestaurantFormOverview :restaurantExists="restaurantExists" />
 
   <div class="restaurant-form">
     <div class="form-container">
@@ -35,8 +35,7 @@ import RestaurantBasicInputs from './RestaurantBasicInputs.vue';
 import AppButton from '../ui/AppButton.vue';
 import { useRestaurantValidator } from '../../composables/useRestaurantValidator';
 import { navigateTo } from '../../utils/navigation';
-import { apiPost } from '../../utils/apiHelper'
-
+import { apiPost, apiPut } from '../../utils/apiHelper'
 
 const props = defineProps ({
   initialData: Object,
@@ -45,6 +44,7 @@ const props = defineProps ({
 
 const initialData = props.initialData
 const currentEmail = props.currentEmail
+const restaurantExists = initialData !== '' && initialData !== null && initialData !== undefined
 
 const restaurant = reactive({
   name: initialData?.name || null,
@@ -70,7 +70,11 @@ function submit() {
 
   console.log('JSON Final para envio:', JSON.stringify(payload, null, 2));
 
-  apiPost('/api/v1/restaurants', payload, 'Restaurante criado com sucesso!')
+  if (restaurantExists) {
+    return apiPut(`/api/v1/restaurants/${initialData.id}`, payload, 'Restaurante atualizado com sucesso!');
+  } else {
+    return apiPost('/api/v1/restaurants', payload, 'Restaurante criado com sucesso!');
+  }
 }
 </script>
 

--- a/app/javascript/components/ui/InputDropdown.vue
+++ b/app/javascript/components/ui/InputDropdown.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="select-group" ref="dropdownRef">
-    <label for="product-select" @click="toggleDropdown">
+    <label :for="id || 'product-select'" @click="toggleDropdown">
       <span class="label-text">{{ label }}</span>
 
       <span v-if="required" class="required-asterisk">*</span>
@@ -9,6 +9,7 @@
     <div class="dropdown-wrapper" @click="toggleDropdown">
       <div class="dropdown-display" @click="toggleDropdown">
         <input
+          :id="id || 'product-select'"
           v-model="searchQuery"
           :placeholder="selectedPlaceholder"
           class="dropdown-input"
@@ -50,6 +51,7 @@ import { Icon } from '@iconify/vue'
 import { useField } from '../../composables/useFields'
 
 const props = defineProps({
+  id: String,
   placeholder: String,
   options: {
     type: Array,

--- a/app/javascript/utils/apiHelper.js
+++ b/app/javascript/utils/apiHelper.js
@@ -15,3 +15,18 @@ export async function apiPost(endpoint, payload, successMessage = 'Operação re
     throw error
   }
 }
+
+export async function apiPut(endpoint, payload, successMessage = 'Operação realizada com sucesso!') {
+  try {
+    const { data } = await axios.put(endpoint, payload, {
+      headers: { 'Content-Type': 'application/json' }
+    })
+    const msg = data?.message || successMessage
+    navigateTo(`/flash?path=${encodeURIComponent('/')}&notice=${encodeURIComponent(msg)}`)
+    return data
+  } catch (error) {
+    const msg = error.response?.data?.errors || 'Erro desconhecido'
+    navigateTo(`/flash?path=${encodeURIComponent(window.location.pathname)}&alert=${encodeURIComponent(msg)}`)
+    throw error
+  }
+}

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      raise NoMethodError, "You must define #resolve in #{self.class}"
+    end
+
+    private
+
+    attr_reader :user, :scope
+  end
+end

--- a/app/policies/restaurant_policy.rb
+++ b/app/policies/restaurant_policy.rb
@@ -1,0 +1,9 @@
+class RestaurantPolicy < ApplicationPolicy
+  def new?
+    user.present? && user.restaurant.blank?
+  end
+
+  def edit?
+    user.present? && record.restaurant_user_id == user.id
+  end
+end

--- a/config/locales/api/v1/restaurants/update.pt-BT.yml
+++ b/config/locales/api/v1/restaurants/update.pt-BT.yml
@@ -1,0 +1,7 @@
+pt-BR:
+  api:
+    v1:
+      restaurants:
+        update:
+          success: "Restaurante atualizado com sucesso!"
+          error: "Erro ao atualizar restaurante"

--- a/config/locales/controllers/pundit.pt-BR.yml
+++ b/config/locales/controllers/pundit.pt-BR.yml
@@ -1,0 +1,4 @@
+pt-BR:
+  alerts:
+    pundit:
+      default: "Você não tem permissão para executar esta ação"

--- a/spec/factories/restaurants.rb
+++ b/spec/factories/restaurants.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :restaurant do
-    name { "MyString" }
-    culinary_style { 1 }
-    description { "MyText" }
-    image { "MyString" }
-    phone { "MyString" }
-    address { "MyString" }
+    name { "Ração de humanos" }
+    culinary_style { 'brazilian' }
+    description { "Venha comer na casa de ração para humanos" }
+    image { "http://imagem.com" }
+    phone { "89 99999-9999" }
+    address { "Rua das Palmeiras, 400" }
     restaurant_user { nil }
   end
 end

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe ApplicationPolicy do
+  let(:user) { double("user") }
+  let(:record) { double("record") }
+  let(:policy) { described_class.new(user, record) }
+
+  describe "default actions" do
+    it "index? returns false" do
+      expect(policy.index?).to be false
+    end
+
+    it "show? returns false" do
+      expect(policy.show?).to be false
+    end
+
+    it "create? returns false" do
+      expect(policy.create?).to be false
+    end
+
+    it "new? delegates to create?" do
+      expect(policy.new?).to eq(policy.create?)
+    end
+
+    it "update? returns false" do
+      expect(policy.update?).to be false
+    end
+
+    it "edit? delegates to update?" do
+      expect(policy.edit?).to eq(policy.update?)
+    end
+
+    it "destroy? returns false" do
+      expect(policy.destroy?).to be false
+    end
+  end
+
+  describe "Scope" do
+    let(:scope) { double("scope") }
+    let(:scope_instance) { described_class::Scope.new(user, scope) }
+
+    it "raises error if resolve not implemented" do
+      expect { scope_instance.resolve }.to raise_error(NoMethodError, /You must define #resolve/)
+    end
+  end
+end

--- a/spec/policies/restaurant_policy_spec.rb
+++ b/spec/policies/restaurant_policy_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe RestaurantPolicy do
+  describe "#new?" do
+    it "permite criar se usuário não tiver restaurante" do
+      user = create(:restaurant_user, restaurant: nil)
+
+      policy = described_class.new(user, Restaurant)
+      expect(policy.new?).to be true
+    end
+
+    it "nega criar se usuário já tiver restaurante" do
+      user = create(:restaurant_user)
+      create(:restaurant, restaurant_user: user)
+
+      policy = described_class.new(user, Restaurant)
+      expect(policy.new?).to be false
+    end
+  end
+
+  describe "#edit?" do
+    it "permite dono editar seu próprio restaurante" do
+      user = create(:restaurant_user)
+      restaurant = create(:restaurant, restaurant_user: user)
+
+      policy = described_class.new(user, restaurant)
+      expect(policy.edit?).to be true
+    end
+
+    it "nega edição se não for o dono" do
+      user = create(:restaurant_user)
+      other_user = create(:restaurant_user, email: 'other@email.com')
+      restaurant = create(:restaurant, restaurant_user: user)
+
+      policy = described_class.new(other_user, restaurant)
+      expect(policy.edit?).to be false
+    end
+  end
+end

--- a/spec/requests/restaurants/user_access_restaurant_new_spec.rb
+++ b/spec/requests/restaurants/user_access_restaurant_new_spec.rb
@@ -16,7 +16,7 @@ describe 'User access new form path' do
         get new_restaurant_path
         expect(response).to have_http_status(302)
         expect(response).to redirect_to(new_restaurant_user_session_path)
-        expect(flash[:alert]).to match(/Para continuar, efetue login ou registre-se./)
+        expect(flash[:alert]).to eq "Para continuar, efetue login ou registre-se."
       end
 
       it 'when restaurant_user already has a restaurant' do
@@ -27,8 +27,8 @@ describe 'User access new form path' do
         get new_restaurant_path
 
         expect(response).to have_http_status(302)
-        expect(response).to redirect_to(edit_restaurant_path user.restaurant)
-        expect(flash[:alert]).to match(/Você já possui um restaurante cadastrado/)
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to eq "Você não tem permissão para executar esta ação"
       end
     end
   end

--- a/spec/requests/restaurants/user_acess_restaurant_edit_spec.rb
+++ b/spec/requests/restaurants/user_acess_restaurant_edit_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+describe 'User access edit form path' do
+  context 'GET restaurant/:id/edit' do
+    it 'successfully' do
+      user = create(:restaurant_user)
+      restaurant = create(:restaurant, restaurant_user: user)
+      login_as(user, scope: :restaurant_user)
+
+      get edit_restaurant_path(restaurant)
+
+      expect(response).to have_http_status(200)
+      expect(flash[:alert]).to be_nil
+      expect(flash[:notice]).to be_nil
+    end
+
+    context 'cannot access' do
+      it 'when not logged in' do
+        user = create(:restaurant_user)
+        restaurant = create(:restaurant, restaurant_user: user)
+
+        get edit_restaurant_path(restaurant)
+
+        expect(response).to have_http_status(302)
+        expect(response).to redirect_to(new_restaurant_user_session_path)
+        expect(flash[:alert]).to eq 'Para continuar, efetue login ou registre-se.'
+        expect(flash[:notice]).to be_nil
+      end
+
+      context 'when trying to access another restaurant' do
+        it 'and current user has restaurant' do
+          user = create(:restaurant_user)
+          other_user = create(:restaurant_user, email: 'other@email.com')
+          create(:restaurant, restaurant_user: user)
+          other_restaurant = create(:restaurant, restaurant_user: other_user)
+          login_as(user, scope: :restaurant_user)
+
+          get edit_restaurant_path(other_restaurant)
+
+          expect(response).to have_http_status(302)
+          expect(response).to redirect_to(root_path)
+          expect(flash[:alert]).to eq 'Você não tem permissão para executar esta ação'
+          expect(flash[:notice]).to be_nil
+        end
+
+        it 'and current user no has restaurant' do
+          user = create(:restaurant_user)
+          other_user = create(:restaurant_user, email: 'other@email.com')
+          other_restaurant = create(:restaurant, restaurant_user: other_user)
+          login_as(user, scope: :restaurant_user)
+
+          get edit_restaurant_path(other_restaurant)
+
+          expect(response).to have_http_status(302)
+          expect(response).to redirect_to(new_restaurant_path)
+          expect(flash[:alert]).to eq "Cadastre seu restaurante para continuar"
+          expect(flash[:notice]).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/system/restaurants/user_create_restaurant_spec.rb
+++ b/spec/system/restaurants/user_create_restaurant_spec.rb
@@ -20,7 +20,7 @@ describe 'User creates a restaurant' do
       expect(page).to have_field('Telefone')
       expect(page).to have_field('Endereço Completo')
       expect(page).not_to have_button('Cancelar')
-      expect(page).not_to have_button('Salvar')
+      expect(page).to have_button('Salvar', disabled: true)
     end
 
     it 'and sees an error message if something goes wrong on the server' do
@@ -96,7 +96,7 @@ describe 'User creates a restaurant' do
       fill_in 'Telefone', with: ''
 
       expect(page).not_to have_button('Cancelar')
-      expect(page).not_to have_button('Salvar')
+      expect(page).to have_button('Salvar', disabled: true)
       expect(page).to have_content('Cadastre seu restaurante para continuar')
       expect(page).to have_content('Nome do restaurante é obrigatório')
       expect(page).to have_content('Estilo culinário é obrigatório')

--- a/spec/system/restaurants/user_updates_restaurant_spec.rb
+++ b/spec/system/restaurants/user_updates_restaurant_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe 'User updates a restaurant', type: :system do
+  let(:restaurant_user) { create(:restaurant_user) }
+  let(:restaurant) { create(:restaurant, name: 'Antigo nome', culinary_style: 'acai',
+                                         description: 'Este é um restaurante', restaurant_user: restaurant_user,
+                                         image: 'http/image.com', phone: '89 99999-9999', address: 'Rua das Palmeiras, 400') }
+
+  before do
+    login_as restaurant_user
+    restaurant
+  end
+
+  it 'successfully updates the restaurant' do
+    visit root_path
+
+    click_on 'Editar'
+
+    fill_in 'Nome', with: 'Novo nome', fill_options: { clear: :backspace }
+    fill_in 'Endereço Completo', with: 'Rua das Oliverias, 100', fill_options: { clear: :backspace }
+    click_button 'Salvar'
+
+    expect(page).to have_content('Restaurante atualizado com sucesso!')
+    expect(page).to have_content('Bem-vindo de volta, Novo nome')
+    expect(restaurant.reload.name).to eq('Novo nome')
+    expect(restaurant.reload.culinary_style).to eq('acai')
+    expect(restaurant.reload.description).to eq('Este é um restaurante')
+    expect(restaurant.reload.restaurant_user).to eq(restaurant_user)
+    expect(restaurant.reload.image).to eq('http/image.com')
+    expect(restaurant.reload.phone).to eq('89 99999-9999')
+    expect(restaurant.reload.address).to eq('Rua das Oliverias, 100')
+  end
+
+  it 'shows validation errors when touch required fields' do
+    visit edit_restaurant_path(restaurant)
+
+    fill_in 'Nome', with: '', fill_options: { clear: :backspace }
+    fill_in 'Descrição', with: '', fill_options: { clear: :backspace }
+    fill_in 'Nome', with: ''
+
+    expect(page).to have_content("Nome do restaurante é obrigatório")
+    expect(page).to have_content("Descrição é obrigatória")
+    expect(page).to have_button('Salvar', disabled: true)
+  end
+
+  it 'and sees an error message if something goes wrong on the server' do
+    login_as(restaurant_user, scope: :restaurant_user)
+
+    allow_any_instance_of(Restaurant).to receive(:save).and_return(false)
+    allow_any_instance_of(Restaurant).to receive_message_chain(:errors, :full_messages)
+                                      .and_return([ "Erro interno no servidor" ])
+
+    visit root_path
+    click_on 'Editar'
+
+    fill_in 'Nome', with: 'Restaurante Bugado'
+    fill_in 'Tipo de Culinária', with: 'Italiana'
+    within '.dropdown-menu' do
+      find('.dropdown-item', text: 'Italiana').click
+    end
+
+    click_on 'Salvar'
+
+    expect(page).to have_content('Erro interno no servidor')
+    expect(page).to have_current_path(edit_restaurant_path(restaurant))
+  end
+end


### PR DESCRIPTION
Conclui issue #38

### Motivações
Esse PR garante que apenas usuários autorizados possam editar informações de restaurantes e adiciona testes de ponta a ponta para validar o comportamento esperado, aumentando a segurança e confiabilidade da aplicação.

### O que foi feito
- Implementadas **policies** para controle de acesso na edição de restaurantes.
- Criado **request spec** para validar permissões de edição.
- Adicionado **system spec** cobrindo o fluxo completo de atualização de restaurantes (sucesso e falha).
- Ajustes no frontend para integrar corretamente com o fluxo de edição.

### Testes
- `spec/policies/` → valida regras de acesso.
- `spec/requests/restaurants/user_acess_restaurant_edit_spec.rb` → cobre cenários de autorização na camada de request.
- `spec/system/restaurants/user_updates_restaurant_spec.rb` → cobre o fluxo de edição no navegador.

### Segurança
- Edição restrita ao **usuário dono do restaurante**.
- Criação só é permitida a usuário que ainda não possui restaurante.
- Tentativas de acesso não autorizado são bloqueadas pelas policies.

### OBS
- Cobertura de teste é de **93.88%** garantido cobertura em todo o fluxo de edição segundo `SimpleCov`. 
