### PR TITLE
Feature: Fluxo de Criação de Categorias

### DIFF
--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -1,0 +1,17 @@
+class Api::V1::CategoriesController < Api::V1::ApplicationController
+  def create
+    category = Category.new(category_params)
+
+    if category.save
+      render json: { message: I18n.t("api.v1.categories.create.success"), category: category }, status: :created
+    else
+      render json: { status: :unprocessable_entity, errors: category.errors.full_messages.join(", ") }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def category_params
+    params.require(:category).permit(:name, :description).merge(restaurant: current_restaurant_user&.restaurant)
+  end
+end

--- a/app/javascript/components/category/CategoryFormModal.vue
+++ b/app/javascript/components/category/CategoryFormModal.vue
@@ -16,6 +16,7 @@
 
       <form @submit.prevent class="form-grid">
         <InputGroup
+          id="name"
           label="Nome"
           placeholder="Nome da categoria"
           v-model="category.name"
@@ -24,6 +25,7 @@
         />
 
         <InputGroup
+          id="description"
           label="Descrição"
           placeholder="Descrição da categoria (opcional)"
           v-model="category.description"
@@ -55,6 +57,7 @@ import BaseModal from '../ui/BaseModal.vue';
 import InputGroup from '../ui/InputGroup.vue';
 import { useCategoryValidator } from '../../composables/useCategoryValidator';
 import AppButton from '../ui/AppButton.vue';
+import { apiPost } from '../../utils/apiHelper';
 
 const category = reactive({
   name: null,
@@ -70,6 +73,13 @@ function submit() {
   };
 
   console.log('JSON Final para envio:', JSON.stringify(payload, null, 2));
+
+  apiPost({
+    endpoint: '/api/v1/categories',
+    payload,
+    successMessage: 'Categoria criada com sucesso!',
+    redirectPath: '/menu'
+  });
 }
 </script>
 

--- a/app/javascript/components/restaurant/RestaurantForm.vue
+++ b/app/javascript/components/restaurant/RestaurantForm.vue
@@ -73,7 +73,11 @@ function submit() {
   if (restaurantExists) {
     return apiPut(`/api/v1/restaurants/${initialData.id}`, payload, 'Restaurante atualizado com sucesso!');
   } else {
-    return apiPost('/api/v1/restaurants', payload, 'Restaurante criado com sucesso!');
+    return apiPost({
+      endpoint: '/api/v1/restaurants',
+      payload,
+      successMessage: 'Restaurante criado com sucesso!'
+    });
   }
 }
 </script>

--- a/app/javascript/components/ui/BaseModal.vue
+++ b/app/javascript/components/ui/BaseModal.vue
@@ -47,7 +47,7 @@ body {
 
 @media (max-width: 758px) {
   .modal-content {
-    height: 80%;
+    height: 70%;
   }
 }
 </style>

--- a/app/javascript/utils/apiHelper.js
+++ b/app/javascript/utils/apiHelper.js
@@ -1,17 +1,26 @@
 import axios from 'axios'
 import { navigateTo } from './navigation'
 
-export async function apiPost(endpoint, payload, successMessage = 'Operação realizada com sucesso!') {
+export async function apiPost({
+  endpoint,
+  payload,
+  successMessage = 'Operação realizada com sucesso!',
+  redirectPath = '/'
+}) {
   try {
     const { data } = await axios.post(endpoint, payload, {
       headers: { 'Content-Type': 'application/json' }
     })
     const msg = data?.message || successMessage
-    navigateTo(`/flash?path=${encodeURIComponent('/')}&notice=${encodeURIComponent(msg)}`)
+    navigateTo(
+      `/flash?path=${encodeURIComponent(redirectPath)}&notice=${encodeURIComponent(msg)}`
+    )
     return data
   } catch (error) {
     const msg = error.response?.data?.errors || 'Erro desconhecido'
-    navigateTo(`/flash?path=${encodeURIComponent(window.location.pathname)}&alert=${encodeURIComponent(msg)}`)
+    navigateTo(
+      `/flash?path=${encodeURIComponent(window.location.pathname)}&alert=${encodeURIComponent(msg)}`
+    )
     throw error
   }
 }

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,5 @@
+class Category < ApplicationRecord
+  belongs_to :restaurant
+
+  validates :name, presence: true
+end

--- a/config/locales/api/v1/categories.pt-BR.yml
+++ b/config/locales/api/v1/categories.pt-BR.yml
@@ -1,0 +1,7 @@
+pt-BR:
+  api:
+    v1:
+      categories:
+        create:
+          success: "Categoria criada com sucesso!"
+          error: "Erro ao criar categoria"

--- a/config/locales/models/category.pt-BR.yml
+++ b/config/locales/models/category.pt-BR.yml
@@ -1,0 +1,9 @@
+pt-BR:
+  activerecord:
+    models:
+      category: categoria
+    attributes:
+      category:
+        name: "Nome"
+        description: "Descrição"
+        restaurant: "Restaurante"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :restaurants, only: %i[create update]
+      resources :categories, only: %i[create]
     end
   end
 

--- a/db/migrate/20250904223425_create_categories.rb
+++ b/db/migrate/20250904223425_create_categories.rb
@@ -1,0 +1,11 @@
+class CreateCategories < ActiveRecord::Migration[8.0]
+  def change
+    create_table :categories do |t|
+      t.string :name
+      t.text :description
+      t.references :restaurant, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_28_151334) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_04_223425) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "categories", force: :cascade do |t|
+    t.string "name"
+    t.text "description"
+    t.bigint "restaurant_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["restaurant_id"], name: "index_categories_on_restaurant_id"
+  end
 
   create_table "restaurant_users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -39,5 +48,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_28_151334) do
     t.index ["restaurant_user_id"], name: "index_restaurants_on_restaurant_user_id"
   end
 
+  add_foreign_key "categories", "restaurants"
   add_foreign_key "restaurants", "restaurant_users"
 end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :category do
+    name { "Combos" }
+    description { "Categoria utilizada para combos" }
+    restaurant { nil }
+  end
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Category, type: :model do
+   let(:user) { create(:restaurant_user) }
+   let(:restaurant) { create(:restaurant, restaurant_user: user) }
+
+  context '.valid' do
+    it 'is invalid without a name' do
+      category = Category.new(name: nil, restaurant: restaurant, description: "Bebidas diversas")
+      expect(category).not_to be_valid
+      expect(category.errors.full_messages).to include("Nome não pode ficar em branco")
+    end
+
+    it 'is valid without a description' do
+      category = Category.new(description: nil, restaurant: restaurant, name: "Bebidas")
+      expect(category).to be_valid
+      expect(category.errors.full_messages).not_to include("Descrição não pode ficar em branco")
+    end
+  end
+end

--- a/spec/requests/api/v1/categories/create_category_spec.rb
+++ b/spec/requests/api/v1/categories/create_category_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+describe "POST /api/v1/categories" do
+  let (:user) { create(:restaurant_user) }
+  let (:restaurant) { create(:restaurant, restaurant_user: user) }
+
+  before do
+    restaurant
+  end
+
+  context "when user is logged in" do
+    it "creates successfully" do
+      category_params = {
+        category: {
+          name: "Pizzas",
+          description: "A test category"
+        }
+      }
+      login_as user
+
+      post api_v1_categories_path, params: category_params
+
+      expect(response).to have_http_status(201)
+      json_response = JSON.parse(response.body)
+      category_response = json_response["category"]
+      expect(category_response["name"]).to eq("Pizzas")
+      expect(category_response["description"]).to eq("A test category")
+      expect(category_response["restaurant_id"]).to eq(restaurant.id)
+    end
+
+    it "returns error if required fields are blank" do
+      category_params = {
+        category: {
+          name: "",
+          description: ""
+        }
+      }
+      login_as user
+
+      post api_v1_categories_path, params: category_params
+
+      expect(response).to have_http_status(422)
+      json_response = JSON.parse(response.body)
+      expect(json_response["errors"]).to include("Nome não pode ficar em branco")
+      expect(json_response["errors"]).not_to include("Descrição não pode ficar em branco")
+    end
+
+    it "to another restaurant" do
+      another_user = create(:restaurant_user, email: 'another@email.com')
+      another_restaurant = create(:restaurant, restaurant_user: another_user)
+      category_params = {
+        category: {
+          name: "Pizzas",
+          description: "A test category",
+          restaurant_id: another_restaurant.id
+        }
+      }
+      login_as user
+
+      post api_v1_categories_path, params: category_params
+
+      expect(response).to have_http_status(201)
+      json_response = JSON.parse(response.body)
+      category_response = json_response["category"]
+      expect(category_response["name"]).to eq("Pizzas")
+      expect(category_response["description"]).to eq("A test category")
+      expect(category_response["restaurant_id"]).to eq(restaurant.id)
+    end
+  end
+
+  context "when user is not logged in" do
+    it "returns unauthorized" do
+      category_params = {
+        category: {
+          name: "Pizzas",
+          description: "A test category"
+        }
+      }
+
+      post api_v1_categories_path, params: category_params
+
+      expect(response).to have_http_status(422)
+      json_response = JSON.parse(response.body)
+      expect(json_response["errors"]).to include("Restaurante é obrigatório(a)")
+    end
+  end
+end

--- a/spec/requests/api/v1/categories/create_category_spec.rb
+++ b/spec/requests/api/v1/categories/create_category_spec.rb
@@ -69,7 +69,7 @@ describe "POST /api/v1/categories" do
   end
 
   context "when user is not logged in" do
-    it "returns unauthorized" do
+    it "returns unprocessable entity" do
       category_params = {
         category: {
           name: "Pizzas",

--- a/spec/system/categories/user_create_category_spec.rb
+++ b/spec/system/categories/user_create_category_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+describe 'User creates a category', type: :system do
+  let(:user) { create(:restaurant_user) }
+  let(:restaurant) { create(:restaurant, restaurant_user: user) }
+
+  before do
+    restaurant
+    login_as user
+    visit root_path
+    find('span', text: 'Gerenciar Menu').click
+    click_button 'Nova Categoria'
+  end
+
+  it 'successfully' do
+    fill_in 'Nome', with: 'Pizzas'
+    fill_in 'Descrição', with: 'Categorias de pizzas diversas'
+    click_button 'Salvar'
+
+    expect(page).to have_content('Categoria criada com sucesso!')
+    expect(page).not_to have_css('.modal-content', visible: true)
+    expect(page).to have_current_path(menu_path)
+    expect(Category.last.name).to eq('Pizzas')
+    expect(Category.last.description).to eq('Categorias de pizzas diversas')
+    expect(Category.last.restaurant).to eq(user.restaurant)
+  end
+
+  it 'and see errors in all required fields after touched' do
+    fill_in 'Nome', with: ''
+    fill_in 'Descrição', with: ''
+    fill_in 'Nome', with: ''
+
+    expect(page).to have_current_path(menu_path)
+      expect(page).to have_css('.modal-content', visible: true)
+    expect(page).to have_content("Nome da categoria é obrigatório")
+    expect(page).not_to have_content("Descrição não pode ficar em branco")
+    expect(page).to have_button('Salvar', disabled: true)
+  end
+
+  it 'and sees an error message if something goes wrong on the server' do
+    allow_any_instance_of(Category).to receive(:save).and_return(false)
+    allow_any_instance_of(Category).to receive_message_chain(:errors, :full_messages)
+                                      .and_return([ "Erro interno no servidor" ])
+
+    fill_in 'Nome', with: 'Pizzas'
+    fill_in 'Descrição', with: 'Categorias de pizzas diversas'
+
+    click_on 'Salvar'
+
+    expect(page).to have_content('Erro interno no servidor')
+    expect(page).not_to have_css('.modal-content', visible: true)
+    expect(page).to have_current_path(menu_path)
+  end
+end


### PR DESCRIPTION
Esse PR fecha issue #34 

## Descrição

Este PR entrega a primeira parte do cadastro de categorias, permitindo que um usuário restaurante crie categorias pela interface web e pela API.

## O que foi feito

- Criação do modelo Category com validações de presença.

- Adicionado endpoint POST /api/v1/categories para cadastro via API.

- Atualização do componente Vue CategoryFormModal para enviar dados à API.

- Refatoração do helper apiPost para aceitar parâmetros nomeados e redirectPath.

- Ajuste no componente RestaurantForm para usar a nova assinatura do apiPost.

- Inclusão de mensagens traduzidas (i18n) para atributos e mensagens de erro.

- Adicionados tests:

  - Factory de Category.

  - Model specs para validações.

  - Request specs cobrindo criação e erros de validação.

  - System spec validando fluxo completo de criação pela interface.

## Motivação

Permitir que restaurantes organizem seus produtos em categorias, garantindo que:

- O fluxo de criação esteja disponível via API e interface web.

- Mensagens de validação sejam exibidas corretamente em ambos os contextos.

- O frontend esteja integrado com a API para persistência consistente.

## Telas da funcionalidade
### Desktop

<img width="1848" height="1011" alt="Captura de tela de 2025-09-05 11-52-37" src="https://github.com/user-attachments/assets/1cdc9b7f-cd48-4175-bcb9-0dac24d3c90e" />
<img width="1831" height="1010" alt="Captura de tela de 2025-09-05 12-01-00" src="https://github.com/user-attachments/assets/2cf59631-0bf3-4137-b2de-afd2d4f71310" />

### Mobile
<img width="389" height="841" alt="Captura de tela de 2025-09-05 11-59-31" src="https://github.com/user-attachments/assets/9fb84740-7fdb-43d1-8e05-ac766f9088f3" />

<img width="389" height="839" alt="image" src="https://github.com/user-attachments/assets/2ae06166-95e7-47d9-918f-dc67c0c4e493" />

## Observações

- Este PR cobre apenas o fluxo create de categorias. Funcionalidades de edição e exclusão serão entregues em PRs posteriores.
- Cobertura de teste é de **97.25%** garantido cobertura em todo o fluxo de criação segundo SimpleCov.