### PR TITLE
# Feature: Fluxo de Criação de Produto

### DIFF
--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -1,4 +1,9 @@
 class Api::V1::CategoriesController < Api::V1::ApplicationController
+  def index
+    categories = current_restaurant_user.restaurant.categories
+    render json: categories.select(:id, :name)
+  end
+
   def create
     category = Category.new(category_params)
 

--- a/app/controllers/api/v1/products_controller.rb
+++ b/app/controllers/api/v1/products_controller.rb
@@ -1,0 +1,29 @@
+class Api::V1::ProductsController < Api::V1::ApplicationController
+  def create
+    product = Product.new(product_params)
+
+    if product.save
+      render json: { message: I18n.t("api.v1.products.create.success"), product: product }, status: :created
+    else
+      render json: { status: :unprocessable_entity, errors: product.errors.full_messages.join(", ") }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def product_params
+    params.require(:product).permit(
+      :name,
+      :category_id,
+      :base_price,
+      :duration,
+      :description,
+      :image,
+      :status,
+      :featured,
+      ingredients: [],
+      modifier_groups_attributes: [ :id, :name, :input_type, :min, :max, :free_limit,
+                        { modifiers_attributes: [ :id, :name, :base_price, :image ] } ]
+    ).merge(restaurant: current_restaurant_user&.restaurant)
+  end
+end

--- a/app/javascript/components/products/ProductForm.vue
+++ b/app/javascript/components/products/ProductForm.vue
@@ -90,6 +90,7 @@ const {
 
 const forceCategoryError = ref(false);
 const { fillProduct } = useProductTemplate(product, forceCategoryError);
+console.log(product)
 
 const hasUnsavedChanges = ref(false);
 

--- a/app/javascript/components/products/ProductForm.vue
+++ b/app/javascript/components/products/ProductForm.vue
@@ -26,7 +26,7 @@
       />
       <ModifierGroup
         v-if="step === 2"
-        v-model="product.modifiers_groups"
+        v-model="product.modifier_groups"
       />
       <ProductViewer v-if="step === 3" :product="product" />
       <div class="form-actions">

--- a/app/javascript/components/products/ProductForm.vue
+++ b/app/javascript/components/products/ProductForm.vue
@@ -72,6 +72,7 @@ import ModifierOptionsPrompt from './StepOne/ModifierOptionsPrompt.vue';
 import ProductBasicInputs from './StepOne/ProductBasicInputs.vue';
 import AppButton from '../ui/AppButton.vue';
 import ProductViewer from './StepThree/ProductViewer.vue';
+import { apiPost } from '../../utils/apiHelper';
 
 const handleStepChange = (stepChoice) => {
   nextStep.value = stepChoice;
@@ -114,18 +115,25 @@ const handleBeforeUnload = (event) => {
 function submit() {
   const payload = {
     name: product.name,
-    category: product.category,
+    category_id: product.category,
     base_price: Number(product.price),
     duration: Number(product.duration),
     description: product.description,
     ingredients: product.ingredients,
     image: product.image_url,
-    is_featured: product.isFeatured,
-    is_active: product.isActive,
-    modifiers_groups: product.modifiers_groups
+    featured: product.isFeatured,
+    status: product.isActive ? 'active' : 'inactive',
+    modifier_groups_attributes: product.modifier_groups
   };
 
   console.log('JSON Final para envio:', JSON.stringify(payload, null, 2));
+
+  apiPost({
+    endpoint: '/api/v1/products',
+    payload,
+    successMessage: 'Produto criado com sucesso!',
+    redirectPath: '/menu'
+  });
 
   hasUnsavedChanges.value = false;
 }

--- a/app/javascript/components/products/StepOne/IngredientsInput.vue
+++ b/app/javascript/components/products/StepOne/IngredientsInput.vue
@@ -5,7 +5,7 @@
       <InputGroup
         id="ingredients"
         v-model="ingredient"
-        placeholder="Digite um ingredientes"
+        placeholder="Digite um ingrediente"
         @keyup.enter="addIngredient"
       />
       <AppButton

--- a/app/javascript/components/products/StepOne/ProductBasicInputs.vue
+++ b/app/javascript/components/products/StepOne/ProductBasicInputs.vue
@@ -19,11 +19,7 @@
 
       <InputDropdown
         v-model="product.category"
-        :options="[
-          { label: 'Bebidas', value: 'bebidas' },
-          { label: 'Comidas', value: 'comidas' },
-          { label: 'Sobremesas', value: 'sobremesas' }
-        ]"
+        :options="categoryOptions"
         placeholder="Todas as categorias"
         :externalError="errors?.category"
         label="Categoria"
@@ -87,7 +83,8 @@ import CurrencyInput from '../../ui/CurrencyInput.vue'
 import InputNumber from '../../ui/InputNumber.vue'
 import ToggleSwitch from '../../ui/ToggleSwitch.vue'
 import IngredientsInput from './IngredientsInput.vue'
-import { toRefs } from 'vue'
+import { toRefs, ref, onMounted } from 'vue'
+import axios from 'axios'
 
 const props = defineProps({
   product: Object,
@@ -98,6 +95,20 @@ const props = defineProps({
 const emit = defineEmits(['update:product'])
 
 const localProduct = toRefs(props.product)
+
+const categoryOptions = ref([])
+
+onMounted(async () => {
+  try {
+    const response = await axios.get('/api/v1/categories')
+    categoryOptions.value = response.data.map(cat => ({
+      label: cat.name,
+      value: cat.id
+    }))
+  } catch (err) {
+    console.error('Erro ao carregar categorias', err)
+  }
+})
 </script>
 
 <style scoped>

--- a/app/javascript/components/products/StepOne/QuickTemplate.vue
+++ b/app/javascript/components/products/StepOne/QuickTemplate.vue
@@ -42,7 +42,7 @@ function selectTemplate(label) {
       isActive: true,
       isFeatured: false,
       ingredients: ['Queijo', 'Tomate', 'Manjericão'],
-      modifiers_groups: [],
+      modifier_groups: [],
     },
     Hambúrguer: {
       name: 'Hambúrguer Clássico',
@@ -53,7 +53,7 @@ function selectTemplate(label) {
       isFeatured: false,
       ingredients: ['Pão', 'Carne', 'Queijo'],
       image_url: 'https://www.minhareceita.com.br/app/uploads/2023/08/x-bacon-portal-minha-receita.jpg',
-      modifiers_groups: [],
+      modifier_groups: [],
     },
     Açaí: {
       name: 'Tigela de Açaí',
@@ -63,7 +63,7 @@ function selectTemplate(label) {
       isActive: true,
       isFeatured: false,
       image_url: 'https://flordejambu.com/wp-content/uploads/2022/05/acai.png',
-      modifiers_groups: [],
+      modifier_groups: [],
     },
     Bebida: {
       name: 'Suco Natural',
@@ -74,7 +74,7 @@ function selectTemplate(label) {
       isFeatured: false,
       ingredients: ['Fruta'],
       image_url: 'https://s3-sa-east-1.amazonaws.com/deliveryon-uploads/products/imperio/38_5c58b562c06f5.jpg',
-      modifiers_groups: [],
+      modifier_groups: [],
     }
   }
 

--- a/app/javascript/components/products/StepThree/ModifierListBase.vue
+++ b/app/javascript/components/products/StepThree/ModifierListBase.vue
@@ -12,7 +12,7 @@
 
     <ul class="modifiers">
       <li
-        v-for="item in modifier_group.modifiers"
+        v-for="item in modifier_group.modifiers_attributes"
         :key="item.id"
         class="modifiers-options"
         :class="{

--- a/app/javascript/components/products/StepThree/ModifierQuantity.vue
+++ b/app/javascript/components/products/StepThree/ModifierQuantity.vue
@@ -105,7 +105,7 @@ const headerProps = computed(() => ({
   
   <ul class="modifiers">
     <li
-    v-for="item in modifier_group.modifiers"
+    v-for="item in modifier_group.modifiers_attributes"
     :key="item.id"
     class="modifiers-options"
     >

--- a/app/javascript/components/products/StepThree/ProductViewer.vue
+++ b/app/javascript/components/products/StepThree/ProductViewer.vue
@@ -18,8 +18,8 @@
       <hr />
 
       <ModifierGroup
-        v-if="product.modifiers_groups?.length > 0"
-        v-for="group in product.modifiers_groups"
+        v-if="product.modifier_groups?.length > 0"
+        v-for="group in product.modifier_groups"
         :key="group.id"
         :modifier_group="group"
         @update:selected="handleUpdateSelected"

--- a/app/javascript/components/products/StepTwo/ModifierGroup.vue
+++ b/app/javascript/components/products/StepTwo/ModifierGroup.vue
@@ -82,13 +82,12 @@ function addGroup(type = '') {
   }
 
   groups.value.push({
-    id: Date.now(),
     name: null,
     input_type: type,
     min: null,
     max: max,
     free_limit: free_limit,
-    modifiers: []
+    modifiers_attributes: []
   })
 }
 
@@ -97,8 +96,7 @@ function removeGroup(index) {
 }
 
 function addModifier(index) {
-  groups.value[index].modifiers.push({
-    id: Date.now(),
+  groups.value[index].modifiers_attributes.push({
     name: null,
     base_price: null,
     image: null,
@@ -106,7 +104,7 @@ function addModifier(index) {
 }
 
 function removeModifier(groupIndex, modifierIndex) {
-  groups.value[groupIndex].modifiers.splice(modifierIndex, 1)
+  groups.value[groupIndex].modifiers_attributes.splice(modifierIndex, 1)
 }
 </script>
 

--- a/app/javascript/components/products/StepTwo/ModifierGroupCard.vue
+++ b/app/javascript/components/products/StepTwo/ModifierGroupCard.vue
@@ -72,17 +72,17 @@
           @update:modelValue="computedFreeLimit = $event"
           :min="0"
           :max="1000"
-          :disabled="group.input_type !== 'quantity'"
+          :disabled="group.input_type === 'single_choice' || group.input_type === 'multiple_choice'"
           :externalError="groupErrors?.free_limit"
           required
         />
       </div>
     </div>
 
-    <ItemChip :item="`${group.modifiers.length} opções`" class="options-chip" />
+    <ItemChip :item="`${group.modifiers_attributes.length} ${group.modifiers_attributes.length != 1 ? 'opções' : 'opção' }`" class="options-chip" />
 
     <ModifierList
-      :modifiers="group.modifiers"
+      :modifiers="group.modifiers_attributes"
       :index="index"
       @add-modifier="$emit('add-modifier', index)"
       @remove-modifier="$emit('remove-modifier', index, $event)"

--- a/app/javascript/composables/useGroupValidator.js
+++ b/app/javascript/composables/useGroupValidator.js
@@ -7,7 +7,7 @@ export function useGroupValidator(group) {
     min: null,
     max: null,
     free_limit: null,
-    modifiers: null
+    modifiers_attributes: null
   })
 
   function validateName() {
@@ -44,9 +44,9 @@ export function useGroupValidator(group) {
   }
 
   function validateModifiers() {
-    const modifiers = group.modifiers
-    if (!modifiers || modifiers.length === 0) return 'Pelo menos um modificador é obrigatório'
-    for (const mod of modifiers) {
+    const modifiers_attributes = group.modifiers_attributes
+    if (!modifiers_attributes || modifiers_attributes.length === 0) return 'Pelo menos um modificador é obrigatório'
+    for (const mod of modifiers_attributes) {
       if (!mod.name?.trim()) {
         return 'Todos os modificadores devem ter nome e preço válidos'
       }
@@ -60,7 +60,7 @@ export function useGroupValidator(group) {
     errors.min = validateMin()
     errors.max = validateMax()
     errors.free_limit = validateFreeLimit()
-    errors.modifiers = validateModifiers()
+    errors.modifiers_attributes = validateModifiers()
   })
 
   const isValid = computed(() =>

--- a/app/javascript/composables/useProductForm.js
+++ b/app/javascript/composables/useProductForm.js
@@ -61,17 +61,14 @@ export function useProductForm() {
 
 export function useProductTemplate(product, forceCategoryError) {
   function fillProduct(template) {
+    console.log(template)
+    product.ingredients.length = 0;
+
+    if (template.ingredients) {
+      product.ingredients.push(...template.ingredients);
+    }
+
     Object.assign(product, {
-      name: null,
-      category: null,
-      price: null,
-      duration: null,
-      description: null,
-      image_url: null,
-      isActive: true,
-      isFeatured: false,
-      ingredients: [],
-      modifier_groups: [],
       ...template
     });
 

--- a/app/javascript/composables/useProductForm.js
+++ b/app/javascript/composables/useProductForm.js
@@ -13,20 +13,20 @@ export function useProductForm() {
     isActive: true,
     isFeatured: false,
     ingredients: [],
-    modifiers_groups: []
+    modifier_groups: []
   });
 
   const step = ref(1);
   const nextStep = ref(null);
 
   const { errors: productErrors, isValid: isProductValid } = useProductValidator(product);
-  const { isValid: areGroupsValid } = useGroupsValidator(computed(() => product.modifiers_groups));
+  const { isValid: areGroupsValid } = useGroupsValidator(computed(() => product.modifier_groups));
 
   const hasMadeStep1Decision = computed(() => nextStep.value !== null);
   const canProceedFromStep1 = computed(() => isProductValid.value && hasMadeStep1Decision.value);
   const isStep1Complete = computed(() => isProductValid.value);
 
-  const hasModifiers = computed(() => product.modifiers_groups.length > 0);
+  const hasModifiers = computed(() => product.modifier_groups.length > 0);
   const canProceedFromStep2 = computed(() => !hasModifiers.value || areGroupsValid.value);
 
   const isFormValid = computed(() => isProductValid.value && canProceedFromStep2.value);
@@ -71,7 +71,7 @@ export function useProductTemplate(product, forceCategoryError) {
       isActive: true,
       isFeatured: false,
       ingredients: [],
-      modifiers_groups: [],
+      modifier_groups: [],
       ...template
     });
 

--- a/app/javascript/composables/useProductValidator.js
+++ b/app/javascript/composables/useProductValidator.js
@@ -14,7 +14,7 @@ export function useProductValidator(product) {
   }
 
   function validateCategory() {
-    return !product.category?.trim() ? 'Categoria é obrigatória' : null
+    return !product.category ? 'Categoria é obrigatória' : null
   }
 
   function validatePrice() {

--- a/app/models/modifier.rb
+++ b/app/models/modifier.rb
@@ -1,0 +1,5 @@
+class Modifier < ApplicationRecord
+  belongs_to :modifier_group
+
+  validates :name, :base_price, :image, presence: true
+end

--- a/app/models/modifier_group.rb
+++ b/app/models/modifier_group.rb
@@ -1,0 +1,46 @@
+class ModifierGroup < ApplicationRecord
+  belongs_to :product
+  has_many :modifiers, dependent: :destroy
+
+  accepts_nested_attributes_for :modifiers, allow_destroy: true
+
+  enum :input_type, { single_choice: 5, multiple_choice: 10, quantity: 15 }
+
+  validates :name, :input_type, :min, :max, :free_limit, presence: true
+  validates :min, comparison: { greater_than_or_equal_to: 0 }
+  validates :max, comparison: { greater_than_or_equal_to: 0 }
+  validates :free_limit, comparison: { greater_than_or_equal_to: 0 }
+
+  validate :max_vs_min_and_free_limit
+  validate :type_specific_limits
+
+  private
+
+  def max_vs_min_and_free_limit
+    if max.present? && min.present? && max < min
+      errors.add(:max, "deve ser maior ou igual a #{self.class.human_attribute_name(:min)}")
+    end
+
+    if max.present? && free_limit.present? && max < free_limit
+      errors.add(:max, "deve ser maior ou igual a #{self.class.human_attribute_name(:free_limit)}")
+    end
+  end
+
+  def type_specific_limits
+    case input_type
+    when "single_choice"   then validate_single_choice
+    when "multiple_choice" then validate_multiple_choice
+    end
+  end
+
+  def validate_single_choice
+    errors.add(:min, I18n.t("modifier_group.single_choice.min")) unless min == 1
+    errors.add(:max, I18n.t("modifier_group.single_choice.max")) unless max == 1
+    errors.add(:free_limit, I18n.t("modifier_group.single_choice.free_limit")) unless free_limit == max
+  end
+
+  def validate_multiple_choice
+    errors.add(:max, I18n.t("modifier_group.multiple_choice.max")) if max < 2
+    errors.add(:free_limit, I18n.t("modifier_group.multiple_choice.free_limit")) unless free_limit == max
+  end
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,0 +1,12 @@
+class Product < ApplicationRecord
+  belongs_to :category
+  belongs_to :restaurant
+
+  has_many :modifier_groups, dependent: :destroy
+  accepts_nested_attributes_for :modifier_groups, allow_destroy: true
+
+  validates :name, :category, :base_price, :duration, :description, :status, presence: true
+  validates :featured, inclusion: { in: [ true, false ] }
+
+  enum :status, { active: 5, inactive: 10 }
+end

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -1,6 +1,8 @@
 class Restaurant < ApplicationRecord
   belongs_to :restaurant_user
 
+  has_many :categories
+
   validates :name, :culinary_style, :description, :image, :phone, presence: true
   validates :restaurant_user_id, uniqueness: true
 

--- a/config/locales/api/v1/products.pt-BR.yml
+++ b/config/locales/api/v1/products.pt-BR.yml
@@ -1,0 +1,7 @@
+pt-BR:
+  api:
+    v1:
+      products:
+        create:
+          success: "Produto criado com sucesso!"
+          error: "Erro ao criar categoria"

--- a/config/locales/models/modifier.pt-BR.yml
+++ b/config/locales/models/modifier.pt-BR.yml
@@ -1,0 +1,9 @@
+pt-BR:
+  activerecord:
+    models:
+      modifier: "Modificador"
+    attributes:
+      modifier:
+        name: "Nome"
+        base_price: "Preço Base"
+        image: "Imagem"

--- a/config/locales/models/modifier_group.pt-BR.yml
+++ b/config/locales/models/modifier_group.pt-BR.yml
@@ -1,0 +1,20 @@
+pt-BR:
+  activerecord:
+    models:
+      modifier_group: "Grupo de Modificador"
+    attributes:
+      modifier_group:
+        name: "Nome"
+        input_type: "Tipo de Escolha"
+        max: "Máximo"
+        min: "Mínimo"
+        free_limit: "Limite Grátis"
+
+  modifier_group:
+    single_choice:
+      min: "em Única Escolha deve ser sempre 1"
+      max: "em Única Escolha deve ser sempre 1"
+      free_limit: "deve ser igual ao valor de Máximo"
+    multiple_choice:
+      max: "deve ser no mínimo 2, em Múltipla Escolha"
+      free_limit: "deve ser igual ao valor de Máximo"

--- a/config/locales/models/product.pt-BR.yml
+++ b/config/locales/models/product.pt-BR.yml
@@ -1,0 +1,16 @@
+pt-BR:
+  activerecord:
+    models:
+      product: "Produto"
+    attributes:
+      product:
+        name: "Nome"
+        category: "Categoria"
+        base_price: "Preço Base"
+        duration: "Tempo de Preparo"
+        description: "Descrição"
+        image: "Imagem"
+        status: "Status"
+        featured: "Produto em Destaque"
+        ingredients: Ingredientes
+        restaurant: "Restaurante"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,8 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :restaurants, only: %i[create update]
-      resources :categories, only: %i[create]
+      resources :categories, only: %i[index create]
+      resources :products, only: %i[create]
     end
   end
 

--- a/db/migrate/20250905221357_create_products.rb
+++ b/db/migrate/20250905221357_create_products.rb
@@ -1,0 +1,18 @@
+class CreateProducts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :products do |t|
+      t.string :name
+      t.references :category, null: false, foreign_key: true
+      t.integer :price
+      t.text :description
+      t.string :ingredients, array: true, default: []
+      t.integer :status
+      t.boolean :featured
+      t.references :restaurant, null: false, foreign_key: true
+      t.integer :duration
+      t.string :image
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250905223021_rename_price_to_base_price_in_products.rb
+++ b/db/migrate/20250905223021_rename_price_to_base_price_in_products.rb
@@ -1,0 +1,5 @@
+class RenamePriceToBasePriceInProducts < ActiveRecord::Migration[8.0]
+  def change
+    rename_column :products, :price, :base_price
+  end
+end

--- a/db/migrate/20250905225418_create_modifier_groups.rb
+++ b/db/migrate/20250905225418_create_modifier_groups.rb
@@ -1,0 +1,14 @@
+class CreateModifierGroups < ActiveRecord::Migration[8.0]
+  def change
+    create_table :modifier_groups do |t|
+      t.string :name
+      t.integer :input_type
+      t.integer :min
+      t.integer :max
+      t.integer :free_limit
+      t.references :product, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250905225558_create_modifiers.rb
+++ b/db/migrate/20250905225558_create_modifiers.rb
@@ -1,0 +1,12 @@
+class CreateModifiers < ActiveRecord::Migration[8.0]
+  def change
+    create_table :modifiers do |t|
+      t.string :name
+      t.integer :base_price
+      t.string :image
+      t.references :modifier_group, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_04_223425) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_05_225558) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -21,6 +21,45 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_04_223425) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["restaurant_id"], name: "index_categories_on_restaurant_id"
+  end
+
+  create_table "modifier_groups", force: :cascade do |t|
+    t.string "name"
+    t.integer "input_type"
+    t.integer "min"
+    t.integer "max"
+    t.integer "free_limit"
+    t.bigint "product_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["product_id"], name: "index_modifier_groups_on_product_id"
+  end
+
+  create_table "modifiers", force: :cascade do |t|
+    t.string "name"
+    t.integer "base_price"
+    t.string "image"
+    t.bigint "modifier_group_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["modifier_group_id"], name: "index_modifiers_on_modifier_group_id"
+  end
+
+  create_table "products", force: :cascade do |t|
+    t.string "name"
+    t.bigint "category_id", null: false
+    t.integer "base_price"
+    t.text "description"
+    t.string "ingredients", default: [], array: true
+    t.integer "status"
+    t.boolean "featured"
+    t.bigint "restaurant_id", null: false
+    t.integer "duration"
+    t.string "image"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_products_on_category_id"
+    t.index ["restaurant_id"], name: "index_products_on_restaurant_id"
   end
 
   create_table "restaurant_users", force: :cascade do |t|
@@ -49,5 +88,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_04_223425) do
   end
 
   add_foreign_key "categories", "restaurants"
+  add_foreign_key "modifier_groups", "products"
+  add_foreign_key "modifiers", "modifier_groups"
+  add_foreign_key "products", "categories"
+  add_foreign_key "products", "restaurants"
   add_foreign_key "restaurants", "restaurant_users"
 end

--- a/spec/factories/modifier_groups.rb
+++ b/spec/factories/modifier_groups.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :modifier_group do
+    association :product
+    name { "Escolha uma bebida" }
+    input_type { :single_choice }
+    min { 1 }
+    max { 1 }
+    free_limit { 1 }
+  end
+end

--- a/spec/factories/modifiers.rb
+++ b/spec/factories/modifiers.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :modifier do
+    name { "MyString" }
+    base_price { 1 }
+    image { "MyString" }
+    modifier_group { nil }
+  end
+end

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :product do
+    name { "MyString" }
+    category { nil }
+    base_price { 1000 }
+    description { "MyText" }
+    ingredients { "MyString" }
+    status { 'active' }
+    featured { false }
+    restaurant { nil }
+    duration { 1 }
+    image { "MyString" }
+  end
+end

--- a/spec/models/modifier_group_spec.rb
+++ b/spec/models/modifier_group_spec.rb
@@ -1,0 +1,124 @@
+require 'rails_helper'
+
+RSpec.describe ModifierGroup, type: :model do
+  let(:user) { create(:restaurant_user) }
+  let(:restaurant) { create(:restaurant, restaurant_user: user) }
+  let(:category)   { create(:category, restaurant:) }
+  let(:product) { create(:product, restaurant:, category:) }
+
+  context '.validations' do
+    context 'presence validations' do
+      it 'is invalid without a name' do
+        modifier_group = ModifierGroup.new(product: product, name: nil)
+        expect(modifier_group).not_to be_valid
+        expect(modifier_group.errors.full_messages).to include("Nome não pode ficar em branco")
+      end
+
+      it 'is invalid without input_type' do
+        modifier_group = ModifierGroup.new(product: product, input_type: nil)
+        expect(modifier_group).not_to be_valid
+        expect(modifier_group.errors.full_messages).to include("Tipo de Escolha não pode ficar em branco")
+      end
+    end
+
+    context 'comparison validations' do
+      it 'is invalid if min is negative' do
+        modifier_group = ModifierGroup.new(product: product, min: -1, max: 1, free_limit: 1)
+        expect(modifier_group).not_to be_valid
+        expect(modifier_group.errors.full_messages).to include("Mínimo deve ser maior ou igual a 0")
+      end
+
+      it 'is invalid if max is less than min' do
+        modifier_group = ModifierGroup.new(product: product, min: 2, max: 1, free_limit: 1)
+        expect(modifier_group).not_to be_valid
+        expect(modifier_group.errors.full_messages).to include("Máximo deve ser maior ou igual a Mínimo")
+      end
+
+      it 'is invalid if max is less than free_limit' do
+        modifier_group = ModifierGroup.new(product: product, min: 1, max: 1, free_limit: 2)
+        expect(modifier_group).not_to be_valid
+        expect(modifier_group.errors.full_messages).to include("Máximo deve ser maior ou igual a Limite Grátis")
+      end
+    end
+
+    context '#validate_type_specific_limits' do
+      context 'single_choice rules' do
+        it 'requires min, max = 1 and free_limit = max' do
+          modifier_group = ModifierGroup.new(
+            product: product,
+            input_type: :single_choice,
+            min: 2,
+            max: 3,
+            free_limit: 2
+          )
+
+          expect(modifier_group).not_to be_valid
+          expect(modifier_group.errors.full_messages).to include(
+            "Mínimo em Única Escolha deve ser sempre 1",
+            "Máximo em Única Escolha deve ser sempre 1",
+            "Limite Grátis deve ser igual ao valor de Máximo"
+          )
+        end
+      end
+
+      context 'multiple_choice rules' do
+        it 'requires max >= 2' do
+          modifier_group = ModifierGroup.new(
+            product: product,
+            input_type: :multiple_choice,
+            min: 1,
+            max: 1,
+            free_limit: 1
+          )
+
+          expect(modifier_group).not_to be_valid
+          expect(modifier_group.errors.full_messages).to include(
+            "Máximo deve ser no mínimo 2, em Múltipla Escolha"
+          )
+        end
+
+        it 'requires free_limit = max' do
+          modifier_group = ModifierGroup.new(
+            product: product,
+            input_type: :multiple_choice,
+            min: 1,
+            max: 3,
+            free_limit: 1
+          )
+
+          expect(modifier_group).not_to be_valid
+          expect(modifier_group.errors.full_messages).to include(
+            "Limite Grátis deve ser igual ao valor de Máximo"
+          )
+        end
+      end
+
+      context 'quantity rules' do
+        it 'allows flexible min, max, and free_limit' do
+          modifier_group = ModifierGroup.new(
+            name: 'Escolha uma bebida',
+            product: product,
+            input_type: :quantity,
+            min: 2,
+            max: 5,
+            free_limit: 3
+          )
+
+          expect(modifier_group).to be_valid
+        end
+
+        it 'is invalid if max < min' do
+          modifier_group = ModifierGroup.new(product: product, input_type: :quantity, min: 3, max: 2, free_limit: 1)
+          expect(modifier_group).not_to be_valid
+          expect(modifier_group.errors.full_messages).to include("Máximo deve ser maior ou igual a Mínimo")
+        end
+
+        it 'is invalid if max < free_limit' do
+          modifier_group = ModifierGroup.new(product: product, input_type: :quantity, min: 1, max: 1, free_limit: 2)
+          expect(modifier_group).not_to be_valid
+          expect(modifier_group.errors.full_messages).to include("Máximo deve ser maior ou igual a Limite Grátis")
+        end
+      end
+    end
+  end
+end

--- a/spec/models/modifier_spec.rb
+++ b/spec/models/modifier_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe Modifier, type: :model do
+  let(:user)        { create(:restaurant_user) }
+  let(:restaurant)  { create(:restaurant, restaurant_user: user) }
+  let(:category)    { create(:category, restaurant:) }
+  let(:product)     { create(:product, restaurant:, category:) }
+  let(:modifier_group) { create(:modifier_group, product:) }
+
+  context 'validations' do
+    it 'is invalid without a name' do
+      modifier = Modifier.new(modifier_group:, name: nil, base_price: 10, image: 'foto.png')
+      expect(modifier).not_to be_valid
+      expect(modifier.errors.full_messages).to include("Nome não pode ficar em branco")
+    end
+
+    it 'is invalid without a base_price' do
+      modifier = Modifier.new(modifier_group:, name: 'Cebola extra', base_price: nil, image: 'foto.png')
+      expect(modifier).not_to be_valid
+      expect(modifier.errors.full_messages).to include("Preço Base não pode ficar em branco")
+    end
+
+    it 'is invalid without an image' do
+      modifier = Modifier.new(modifier_group:, name: 'Cebola extra', base_price: 10, image: nil)
+      expect(modifier).not_to be_valid
+      expect(modifier.errors.full_messages).to include("Imagem não pode ficar em branco")
+    end
+
+    it 'is valid with all required attributes' do
+      modifier = Modifier.new(modifier_group:, name: 'Cebola extra', base_price: 10, image: 'foto.png')
+      expect(modifier).to be_valid
+    end
+  end
+end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe Product, type: :model do
+  let(:user) { create(:restaurant_user) }
+  let(:restaurant) { create(:restaurant, restaurant_user: user) }
+  let(:category)   { create(:category, restaurant:) }
+
+  context '.valid' do
+    it 'is invalid without a name' do
+      product = Product.new(name: nil, category: category, restaurant: restaurant,
+                            base_price: 1000, duration: 10, description: 'Teste',
+                            status: :active, featured: true)
+      expect(product).not_to be_valid
+      expect(product.errors.full_messages).to include("Nome não pode ficar em branco")
+    end
+
+    it 'is invalid without a category' do
+      product = Product.new(name: 'Pizza', category: nil, restaurant: restaurant,
+                            base_price: 1000, duration: 10, description: 'Teste',
+                            status: :active, featured: true)
+      expect(product).not_to be_valid
+      expect(product.errors.full_messages).to include("Categoria não pode ficar em branco")
+    end
+
+    it 'is invalid without a base_price' do
+      product = Product.new(name: 'Pizza', category: category, restaurant: restaurant,
+                            base_price: nil, duration: 10, description: 'Teste',
+                            status: :active, featured: true)
+      expect(product).not_to be_valid
+      expect(product.errors.full_messages).to include("Preço Base não pode ficar em branco")
+    end
+
+    it 'is invalid without a duration' do
+      product = Product.new(name: 'Pizza', category: category, restaurant: restaurant,
+                            base_price: 1000, duration: nil, description: 'Teste',
+                            status: :active, featured: true)
+      expect(product).not_to be_valid
+      expect(product.errors.full_messages).to include("Tempo de Preparo não pode ficar em branco")
+    end
+
+    it 'is invalid without a description' do
+      product = Product.new(name: 'Pizza', category: category, restaurant: restaurant,
+                            base_price: 1000, duration: 10, description: nil,
+                            status: :active, featured: true)
+      expect(product).not_to be_valid
+      expect(product.errors.full_messages).to include("Descrição não pode ficar em branco")
+    end
+
+    it 'is invalid without a status' do
+      product = Product.new(name: 'Pizza', category: category, restaurant: restaurant,
+                            base_price: 1000, duration: 10, description: 'Teste',
+                            status: nil, featured: true)
+      expect(product).not_to be_valid
+      expect(product.errors.full_messages).to include("Status não pode ficar em branco")
+    end
+
+    it 'is invalid without featured flag' do
+      product = Product.new(name: 'Pizza', category: category, restaurant: restaurant,
+                            base_price: 1000, duration: 10, description: 'Teste',
+                            status: :active, featured: nil)
+      expect(product).not_to be_valid
+      expect(product.errors.full_messages).to include("Produto em Destaque não está incluído na lista")
+    end
+
+    it 'is valid with all attributes' do
+      product = Product.new(name: 'Pizza', category: category, restaurant: restaurant,
+                            base_price: 1000, duration: 10, description: 'Teste',
+                            status: :active, featured: true)
+      expect(product).to be_valid
+    end
+  end
+end

--- a/spec/requests/api/v1/products/create_product_spec.rb
+++ b/spec/requests/api/v1/products/create_product_spec.rb
@@ -1,0 +1,97 @@
+require "rails_helper"
+
+describe "POST /api/v1/products" do
+  context "when user is logged in" do
+    it "creates successfully" do
+      user = create(:restaurant_user)
+      restaurant = create(:restaurant, restaurant_user: user)
+      category = create(:category, restaurant: restaurant)
+
+      product_params = {
+        product: {
+          name: "Pizza Margherita",
+          category_id: category.id,
+          base_price: 25.0,
+          duration: 30,
+          description: "Clássica pizza italiana",
+          image: "https://example.com/pizza.png",
+          status: "active",
+          featured: true
+        }
+      }
+      login_as user
+
+      post api_v1_products_path, params: product_params
+
+      expect(response).to have_http_status(201)
+      json_response = JSON.parse(response.body)
+      product_response = json_response["product"]
+
+      expect(product_response["name"]).to eq("Pizza Margherita")
+      expect(product_response["category_id"]).to eq(category.id)
+      expect(product_response["restaurant_id"]).to eq(restaurant.id)
+      expect(product_response["description"]).to eq("Clássica pizza italiana")
+    end
+
+    it "returns error if required fields are blank" do
+      user = create(:restaurant_user)
+      restaurant = create(:restaurant, restaurant_user: user)
+      category = create(:category, restaurant: restaurant)
+
+      product_params = {
+        product: {
+          name: "",
+          category_id: nil,
+          base_price: nil,
+          duration: nil,
+          description: "",
+          image: "",
+          status: "",
+          featured: nil
+        }
+      }
+      login_as user
+
+      post api_v1_products_path, params: product_params
+
+      expect(response).to have_http_status(422)
+      json_response = JSON.parse(response.body)
+
+      expect(json_response["errors"]).to include("Nome não pode ficar em branco")
+      expect(json_response["errors"]).to include("Categoria não pode ficar em branco")
+      expect(json_response["errors"]).to include("Preço Base não pode ficar em branco")
+      expect(json_response["errors"]).to include("Tempo de Preparo não pode ficar em branco")
+      expect(json_response["errors"]).to include("Descrição não pode ficar em branco")
+      expect(json_response["errors"]).not_to include("Imagem não pode ficar em branco")
+      expect(json_response["errors"]).to include("Status não pode ficar em branco")
+      expect(json_response["errors"]).to include("Produto em Destaque não está incluído na lista")
+    end
+  end
+
+  context "when user is not logged in" do
+    it "returns unauthorized" do
+      user = create(:restaurant_user)
+      restaurant = create(:restaurant, restaurant_user: user)
+      category = create(:category, restaurant: restaurant)
+
+      product_params = {
+        product: {
+          name: "Pizza",
+          category_id: category.id,
+          base_price: 20,
+          duration: 15,
+          description: "Boa pizza",
+          image: "https://example.com/pizza.png",
+          status: "active",
+          featured: false
+        }
+      }
+
+      post api_v1_products_path, params: product_params
+
+      expect(response).to have_http_status(422)
+      json_response = JSON.parse(response.body)
+      expect(json_response["errors"]).to include("Restaurante é obrigatório(a)")
+    end
+  end
+end

--- a/spec/system/products/user_create_product_spec.rb
+++ b/spec/system/products/user_create_product_spec.rb
@@ -1,0 +1,111 @@
+require 'rails_helper'
+
+describe 'User creates a product', type: :system do
+  let(:user) { create(:restaurant_user) }
+  let(:restaurant) { create(:restaurant, restaurant_user: user) }
+  let(:category) { create(:category, name: 'Combos', restaurant: restaurant) }
+
+  before do
+    restaurant
+    category
+    login_as user
+    visit root_path
+    find('span', text: 'Gerenciar Menu').click
+    click_button 'Novo Produto'
+  end
+
+  it 'successfully with multiple groups and modifiers' do
+    # Arrange
+    fill_in 'Nome', with: 'Combo Mix'
+    fill_in 'Categoria', with: 'Comb'
+    within '.dropdown-menu' do
+      find('.dropdown-item', text: 'Combos').click
+    end
+    fill_in 'Preço', with: '4990'
+    fill_in 'Tempo de preparo', with: '14'
+    fill_in 'Descrição', with: 'Este é um combo mix'
+    fill_in 'Imagem', with: 'http://productimage.com'
+    fill_in 'Ingredientes', with: 'Bebidas'
+    click_button 'Incluir'
+    find('label', text: 'Produto em destaque').click
+    click_button 'Sim, adicionar opções'
+    click_button 'Continuar'
+
+    # === first group(1 modifier) ===
+    click_button 'Escolha Única'
+    click_button 'Adicionar Opção'
+    find('[placeholder="Nome do Grupo"]').set('Escolha uma bebida')
+    fill_in 'Min de Opções', with: '1'
+    find('[placeholder="Nome da Opção"]').set('Água')
+    fill_in 'Preço', with: '100'
+    find('[placeholder="URL da Imagem"]').set('http://image.com')
+
+    # === second group (2 modifiers) ===
+    click_button 'Adicionar Grupo'
+    within all('.modifier-group-card').last do
+      fill_in 'Tipo de Escolha', with: 'Escolha'
+      within '.dropdown-menu' do
+        find('.dropdown-item', text: 'Escolha Única').click
+      end
+      click_button 'Adicionar Opção'
+      find('[placeholder="Nome do Grupo"]').set('Escolha uma sobremesa')
+      fill_in 'Min de Opções', with: '1'
+
+      # first modifier
+      find('[placeholder="Nome da Opção"]').set('Pudim')
+      fill_in 'Preço', with: '200'
+      find('[placeholder="URL da Imagem"]').set('http://image.com/pudim')
+
+      # first modifier
+      click_button 'Adicionar Opção'
+      all('[placeholder="Nome da Opção"]').last.set('Bolo')
+      all('[id="product-price"]').last.set('300')
+      all('[placeholder="URL da Imagem"]').last.set('http://image.com/bolo')
+    end
+
+    # Act
+    click_button 'Continuar'
+    click_button 'Salvar'
+
+    # Assert
+    expect(page).to have_content 'Produto criado com sucesso!'
+    expect(page).to have_current_path(menu_path)
+
+    product = Product.last
+    expect(product.name).to eq('Combo Mix')
+    expect(product.category).to eq(category)
+    expect(product.base_price).to eq(4990)
+    expect(product.duration).to eq(14)
+    expect(product.description).to eq('Este é um combo mix')
+    expect(product.image).to eq('http://productimage.com')
+    expect(product.ingredients).to eq([ 'Bebidas' ])
+    expect(product.status).to eq('active')
+    expect(product.featured).to eq(true)
+    expect(product.restaurant).to eq(user.restaurant)
+
+    # first group
+    group1 = product.modifier_groups.find_by(name: 'Escolha uma bebida')
+    expect(group1.input_type).to eq('single_choice')
+    expect(group1.min).to eq(1)
+    expect(group1.max).to eq(1)
+    expect(group1.free_limit).to eq(1)
+
+    modifier1 = group1.modifiers.last
+    expect(modifier1.name).to eq('Água')
+    expect(modifier1.base_price).to eq(100)
+    expect(modifier1.image).to eq('http://image.com')
+
+    # second group
+    group2 = product.modifier_groups.find_by(name: 'Escolha uma sobremesa')
+    expect(group2.input_type).to eq('single_choice')
+    expect(group2.min).to eq(1)
+    expect(group2.max).to eq(1)
+    expect(group2.free_limit).to eq(1)
+
+    modifiers2 = group2.modifiers
+    expect(modifiers2.map(&:name)).to contain_exactly('Pudim', 'Bolo')
+    expect(modifiers2.map(&:base_price)).to contain_exactly(200, 300)
+    expect(modifiers2.map(&:image)).to contain_exactly('http://image.com/pudim', 'http://image.com/bolo')
+  end
+
+end

--- a/spec/system/products/user_view_product_form_spec.rb
+++ b/spec/system/products/user_view_product_form_spec.rb
@@ -1,0 +1,239 @@
+require 'rails_helper'
+
+describe 'User view product form', type: :system do
+  let(:user) { create(:restaurant_user) }
+  let(:restaurant) { create(:restaurant, restaurant_user: user) }
+  let(:category) { create(:category, name: 'Combos', restaurant: restaurant) }
+
+  before do
+    restaurant
+    category
+    login_as user
+    visit root_path
+    find('span', text: 'Gerenciar Menu').click
+    click_button 'Novo Produto'
+  end
+
+  context 'in first step' do
+    it "and see fields" do
+      expect(page).to have_field('Nome', with: '', placeholder: 'Nome do Produto')
+      expect(page).to have_field('Categoria', with: '', placeholder: 'Todas as categorias')
+      expect(page).to have_field('Preço', with: '0,00')
+      expect(page).to have_field('Tempo de preparo', with: '', placeholder: 'Tempo de preparo (minutos)')
+      expect(page).to have_field('Descrição', with: '', placeholder: 'Descreva o produto...')
+      expect(page).to have_field('Imagem', with: '', placeholder: 'Imagem')
+      expect(page).to have_field('Ingredientes', with: '', placeholder: 'Digite um ingrediente')
+      expect(page).to have_button('Incluir', disabled: true)
+      toggle_active_product = find_field('Produto ativo', type: 'checkbox', visible: false)
+      expect(toggle_active_product).to be_checked
+      toggle_featured_product = find_field('Produto em destaque', type: 'checkbox', visible: false)
+      expect(toggle_featured_product).not_to be_checked
+      expect(page).to have_button('Continuar', disabled: true)
+      expect(page).not_to have_css('.cancel', text: 'Voltar')
+    end
+
+    it 'and see errors in all required fields after touched' do
+      fill_in 'Nome', with: ''
+      fill_in 'Categoria', with: ''
+      within '.dropdown-menu' do
+        find('.dropdown-item', text: 'Todas as categorias').click
+      end
+      fill_in 'Preço', with: ''
+      fill_in 'Tempo de preparo', with: ''
+      fill_in 'Descrição', with: ''
+      fill_in 'Imagem', with: ''
+      fill_in 'Descrição', with: ''
+
+      expect(page).to have_content 'Nome do produto é obrigatório'
+      expect(page).to have_content 'Categoria é obrigatória'
+      expect(page).to have_content 'Preço é obrigatório'
+      expect(page).to have_content 'Tempo de preparo é obrigatório'
+      expect(page).to have_content 'Descrição é obrigatória'
+      expect(page).not_to have_content 'Imagem do produto é obrigatório'
+    end
+  end
+
+  context 'in second step' do
+    it "and see fields" do
+      fill_first_step
+      click_button 'Sim, adicionar opções'
+      click_button 'Continuar'
+      click_button 'Escolha Única'
+      click_button 'Adicionar Opção'
+
+      input_group_name = find('input[placeholder="Nome do Grupo"]')
+      expect(input_group_name.value).to eq('')
+      expect(page).to have_field('Tipo de Escolha', placeholder: 'Escolha Única')
+      expect(page).to have_field('Min de Opções', with: '', placeholder: 'Mínimo')
+      expect(page).to have_field('Max de Opções', with: '1', placeholder: 'Máximo', disabled: true)
+      expect(page).to have_field('Limite Grátis', with: '1', placeholder: 'Quantidade', disabled: true)
+      expect(page).to have_content('1 opção')
+      input_option_name = find('input[placeholder="Nome do Grupo"]')
+      expect(input_option_name.value).to eq('')
+      expect(page).to have_field('Preço', with: '0,00')
+      input_image = find('input[placeholder="URL da Imagem"]')
+      expect(input_image.value).to eq('')
+      expect(page).to have_css('.cancel', text: 'Voltar')
+    end
+
+    context 'and see errors in all required fields' do
+      it 'that is blanked' do
+        fill_first_step
+        click_button 'Incluir'
+        click_button 'Sim, adicionar opções'
+        click_button 'Continuar'
+        click_button 'Quantidade'
+        click_button 'Adicionar Opção'
+
+        find('[placeholder="Nome do Grupo"]').set('Escolha uma bebida')
+        fill_in 'Tipo de Escolha', with: ''
+        within '.dropdown-menu' do
+          find('.dropdown-item', text: 'Selecionar Tipo de escolha').click
+        end
+        fill_in 'Min de Opções', with: ''
+        fill_in 'Max de Opções', with: ''
+        fill_in 'Limite Grátis', with: ''
+        find('[placeholder="Nome da Opção"]').set('')
+        fill_in 'Preço', with: '0,00'
+        find('[placeholder="URL da Imagem"]').set('')
+
+        within '.modifier-group-card' do
+          expect(page).to have_content 'Nome é obrigatório'
+          expect(page).to have_content 'Tipo é obrigatório'
+          expect(page).to have_content 'Min é obrigatório'
+          expect(page).to have_content 'Máx é obrigatório'
+          expect(page).to have_content 'Limite grátis é obrigatório'
+        end
+        within '.modifier-row' do
+          expect(page).to have_content 'Nome é obrigatório'
+          expect(page).not_to have_content 'Preço é obrigatório'
+          expect(page).not_to have_content 'Imagem é obrigatório'
+        end
+      end
+
+      it 'for max to be less that min and quantity' do
+        fill_first_step
+        click_button 'Incluir'
+        click_button 'Sim, adicionar opções'
+        click_button 'Continuar'
+        click_button 'Quantidade'
+
+        fill_in 'Min de Opções', with: '4'
+        fill_in 'Max de Opções', with: '3'
+        fill_in 'Limite Grátis', with: '4'
+        find('[placeholder="Nome do Grupo"]').set('Escolha uma bebida')
+
+        within '.modifier-group-card' do
+          expect(page).to have_content '0 opções'
+          expect(page).to have_content 'Máx deve ser maior que o Mín'
+          expect(page).to have_content 'Limite grátis não pode ser maior que max'
+          expect(page).to have_field 'Min de Opções', disabled: false
+          expect(page).to have_field 'Max de Opções', disabled: false
+          expect(page).to have_field 'Limite Grátis', disabled: false
+        end
+        expect(page).to have_css('.cancel', text: 'Voltar')
+        expect(page).to have_button 'Continuar', disabled: true
+      end
+
+      it 'for max to be 0' do
+        fill_first_step
+        click_button 'Incluir'
+        click_button 'Sim, adicionar opções'
+        click_button 'Continuar'
+        click_button 'Múltipla Escolha'
+
+        fill_in 'Max de Opções', with: '0'
+        fill_in 'Min de Opções', with: '1'
+        find('[placeholder="Nome do Grupo"]').set('Escolha uma bebida')
+
+        within '.modifier-group-card' do
+          expect(page).to have_field 'Min de Opções', disabled: false
+          expect(page).to have_field 'Max de Opções', disabled: false
+          expect(page).to have_content 'Máx não pode ser 0'
+          expect(page).to have_field 'Limite Grátis', disabled: true
+        end
+        expect(page).to have_css('.cancel', text: 'Voltar')
+        expect(page).to have_button 'Continuar', disabled: true
+      end
+
+      it 'for multiple_choice to be 1' do
+        fill_first_step
+        click_button 'Incluir'
+        click_button 'Sim, adicionar opções'
+        click_button 'Continuar'
+        click_button 'Múltipla Escolha'
+
+        fill_in 'Max de Opções', with: '1'
+        fill_in 'Min de Opções', with: '1'
+        find('[placeholder="Nome do Grupo"]').set('Escolha uma bebida')
+
+        within '.modifier-group-card' do
+          expect(page).to have_field 'Min de Opções', disabled: false
+          expect(page).to have_field 'Max de Opções', disabled: false
+          expect(page).to have_content "Múltipla Escolha:\nMáx deve ser maior"
+          expect(page).to have_field 'Limite Grátis', disabled: true
+        end
+        expect(page).to have_css('.cancel', text: 'Voltar')
+        expect(page).to have_button 'Continuar', disabled: true
+      end
+    end
+  end
+
+  context 'in third step' do
+    it "and see third steps'fields" do
+      go_to_third_step
+
+      expect(page).to have_content 'Combo Mix'
+      expect(page).to have_content 'Este é um combo mix'
+      expect(page).to have_content 'R$ 49,90'
+      expect(page).to have_content '14 min'
+      within '.header-modifier' do
+        expect(page).to have_content 'Escolha uma bebida'
+        expect(page).to have_content 'Escolha 1 grátis'
+        expect(page).to have_content '0/1'
+      end
+
+      within '.modifiers' do
+        expect(page).to have_content 'Água'
+        expect(page).to have_content 'Incluso'
+        expect(page).to have_css '.custom-checkbox'
+      end
+      expect(page).to have_content 'Ingredientes:'
+      expect(page).to have_content 'Bebidas'
+      expect(page).to have_css('.cancel', text: 'Voltar')
+      expect(page).to have_content 'Salvar'
+    end
+  end
+
+  def fill_first_step(name: 'Combo Mix', category: 'Combos', price: '4990',
+                      duration: '14', description: 'Este é um combo mix',
+                      ingredients: 'Bebidas')
+    fill_in 'Nome', with: name
+    fill_in 'Categoria', with: category[0..2]
+    within '.dropdown-menu' do
+      find('.dropdown-item', text: category).click
+    end
+    fill_in 'Preço', with: price
+    fill_in 'Tempo de preparo', with: duration
+    fill_in 'Descrição', with: description
+    fill_in 'Ingredientes', with: ingredients if ingredients
+  end
+
+  def go_to_second_step
+    click_button 'Sim, adicionar opções'
+    click_button 'Continuar'
+  end
+
+  def go_to_third_step
+    fill_first_step
+    click_button 'Incluir'
+    go_to_second_step
+    click_button 'Escolha Única'
+    click_button 'Adicionar Opção'
+    find('[placeholder="Nome do Grupo"]').set('Escolha uma bebida')
+    fill_in 'Min de Opções', with: '1'
+    find('[placeholder="Nome da Opção"]').set('Água')
+    fill_in 'Preço', with: '1'
+    click_button 'Continuar'
+  end
+end

--- a/spec/system/products/user_view_product_form_spec.rb
+++ b/spec/system/products/user_view_product_form_spec.rb
@@ -16,20 +16,171 @@ describe 'User view product form', type: :system do
 
   context 'in first step' do
     it "and see fields" do
-      expect(page).to have_field('Nome', with: '', placeholder: 'Nome do Produto')
-      expect(page).to have_field('Categoria', with: '', placeholder: 'Todas as categorias')
-      expect(page).to have_field('Preço', with: '0,00')
-      expect(page).to have_field('Tempo de preparo', with: '', placeholder: 'Tempo de preparo (minutos)')
-      expect(page).to have_field('Descrição', with: '', placeholder: 'Descreva o produto...')
-      expect(page).to have_field('Imagem', with: '', placeholder: 'Imagem')
-      expect(page).to have_field('Ingredientes', with: '', placeholder: 'Digite um ingrediente')
-      expect(page).to have_button('Incluir', disabled: true)
-      toggle_active_product = find_field('Produto ativo', type: 'checkbox', visible: false)
-      expect(toggle_active_product).to be_checked
-      toggle_featured_product = find_field('Produto em destaque', type: 'checkbox', visible: false)
-      expect(toggle_featured_product).not_to be_checked
+      within '.step-indicator' do
+        within find('[class="step-label active"]') do
+          expect(page).to have_content 'Informações Básicas'
+          expect(page).not_to have_content 'Modificadores'
+          expect(page).not_to have_content 'Revisão'
+        end
+        expect(page).to have_content 'Modificadores'
+        expect(page).to have_content 'Revisão'
+      end
+
+      within '.quick-container' do
+        expect(page).to have_content 'Ações rápidas'
+        expect(page).to have_content 'Escolha um template para preencher automaticamente'
+        expect(page).to have_content 'Pizza'
+        expect(page).to have_content 'Hambúrguer'
+        expect(page).to have_content 'Açaí'
+        expect(page).to have_content 'Bebida'
+      end
+
+      within '.form-grid' do
+        expect(page).to have_field('Nome', with: '', placeholder: 'Nome do Produto')
+        expect(page).to have_field('Categoria', with: '', placeholder: 'Todas as categorias')
+        expect(page).to have_field('Preço', with: '0,00')
+        expect(page).to have_field('Tempo de preparo', with: '', placeholder: 'Tempo de preparo (minutos)')
+        expect(page).to have_field('Descrição', with: '', placeholder: 'Descreva o produto...')
+        expect(page).to have_field('Imagem', with: '', placeholder: 'Imagem')
+        expect(page).to have_field('Ingredientes', with: '', placeholder: 'Digite um ingrediente')
+        expect(page).to have_button('Incluir', disabled: true)
+        toggle_active_product = find_field('Produto ativo', type: 'checkbox', visible: false)
+        expect(toggle_active_product).to be_checked
+        toggle_featured_product = find_field('Produto em destaque', type: 'checkbox', visible: false)
+        expect(toggle_featured_product).not_to be_checked
+      end
+
       expect(page).to have_button('Continuar', disabled: true)
       expect(page).not_to have_css('.cancel', text: 'Voltar')
+    end
+
+    context "and use quick template" do
+      it 'for filling like Pizza' do
+        within '.quick-container' do
+          find('span', text: 'Pizza').click
+        end
+
+        within '.form-grid' do
+          expect(page).to have_field('Nome', with: 'Pizza Margherita', placeholder: 'Nome do Produto')
+          expect(page).to have_field('Categoria', with: '', placeholder: 'Todas as categorias')
+          expect(page).to have_content('Categoria é obrigatória')
+          expect(page).to have_field('Preço', with: '35,90')
+          expect(page).to have_field('Tempo de preparo', with: '25', placeholder: 'Tempo de preparo (minutos)')
+          expect(page).to have_field('Descrição', with: 'Deliciosa pizza de queijo e tomate.', placeholder: 'Descreva o produto...')
+          expect(page).to have_field(
+            'Imagem',
+            with: 'https://static.itdg.com.br/images/1200-630/47d6583c93d77edac5244cab67ba660b/253447-378226756-original.jpg',
+            placeholder: 'Imagem'
+          )
+          expect(page).to have_field('Ingredientes', with: '', placeholder: 'Digite um ingrediente')
+          expect(page).to have_button('Incluir', disabled: true)
+          within '.chips-container' do
+            expect(page).to have_content("Queijo\n×\nTomate\n×\nManjericão\n×")
+          end
+          toggle_active_product = find_field('Produto ativo', type: 'checkbox', visible: false)
+          expect(toggle_active_product).to be_checked
+          toggle_featured_product = find_field('Produto em destaque', type: 'checkbox', visible: false)
+          expect(toggle_featured_product).not_to be_checked
+        end
+
+        expect(page).to have_button('Continuar', disabled: true)
+        expect(page).not_to have_css('.cancel', text: 'Voltar')
+      end
+
+      it 'for filling like Hambúrguer' do
+        within '.quick-container' do
+          find('span', text: 'Hambúrguer').click
+        end
+
+        within '.form-grid' do
+          expect(page).to have_field('Nome', with: 'Hambúrguer Clássico', placeholder: 'Nome do Produto')
+          expect(page).to have_field('Categoria', with: '', placeholder: 'Todas as categorias')
+          expect(page).to have_content('Categoria é obrigatória')
+          expect(page).to have_field('Preço', with: '28,50')
+          expect(page).to have_field('Tempo de preparo', with: '20', placeholder: 'Tempo de preparo (minutos)')
+          expect(page).to have_field('Descrição', with: 'Pão, carne, queijo e molho especial.', placeholder: 'Descreva o produto...')
+          expect(page).to have_field(
+            'Imagem',
+            with: 'https://www.minhareceita.com.br/app/uploads/2023/08/x-bacon-portal-minha-receita.jpg',
+            placeholder: 'Imagem'
+          )
+          expect(page).to have_field('Ingredientes', with: '', placeholder: 'Digite um ingrediente')
+          expect(page).to have_button('Incluir', disabled: true)
+          within '.chips-container' do
+            expect(page).to have_content("Pão\n×\nCarne\n×\nQueijo\n×")
+          end
+          toggle_active_product = find_field('Produto ativo', type: 'checkbox', visible: false)
+          expect(toggle_active_product).to be_checked
+          toggle_featured_product = find_field('Produto em destaque', type: 'checkbox', visible: false)
+          expect(toggle_featured_product).not_to be_checked
+        end
+
+        expect(page).to have_button('Continuar', disabled: true)
+        expect(page).not_to have_css('.cancel', text: 'Voltar')
+      end
+
+      it 'for filling like Açaí' do
+         within '.quick-container' do
+          find('span', text: 'Açaí').click
+        end
+
+        within '.form-grid' do
+          expect(page).to have_field('Nome', with: 'Tigela de Açaí', placeholder: 'Nome do Produto')
+          expect(page).to have_field('Categoria', with: '', placeholder: 'Todas as categorias')
+          expect(page).to have_content('Categoria é obrigatória')
+          expect(page).to have_field('Preço', with: '18,00')
+          expect(page).to have_field('Tempo de preparo', with: '15', placeholder: 'Tempo de preparo (minutos)')
+          expect(page).to have_field('Descrição', with: 'Açaí com banana, granola e mel.', placeholder: 'Descreva o produto...')
+          expect(page).to have_field(
+            'Imagem',
+            with: 'https://flordejambu.com/wp-content/uploads/2022/05/acai.png',
+            placeholder: 'Imagem'
+          )
+          expect(page).to have_field('Ingredientes', with: '', placeholder: 'Digite um ingrediente')
+          expect(page).to have_button('Incluir', disabled: true)
+          expect(page).not_to have_css '.chips-container'
+
+          toggle_active_product = find_field('Produto ativo', type: 'checkbox', visible: false)
+          expect(toggle_active_product).to be_checked
+          toggle_featured_product = find_field('Produto em destaque', type: 'checkbox', visible: false)
+          expect(toggle_featured_product).not_to be_checked
+        end
+
+        expect(page).to have_button('Continuar', disabled: true)
+        expect(page).not_to have_css('.cancel', text: 'Voltar')
+      end
+
+      it 'for filling like Bebida' do
+        within '.quick-container' do
+          find('span', text: 'Bebida').click
+        end
+
+        within '.form-grid' do
+          expect(page).to have_field('Nome', with: 'Suco Natural', placeholder: 'Nome do Produto')
+          expect(page).to have_field('Categoria', with: '', placeholder: 'Todas as categorias')
+          expect(page).to have_content('Categoria é obrigatória')
+          expect(page).to have_field('Preço', with: '7,50')
+          expect(page).to have_field('Tempo de preparo', with: '5', placeholder: 'Tempo de preparo (minutos)')
+          expect(page).to have_field('Descrição', with: 'Suco natural de frutas frescas.', placeholder: 'Descreva o produto...')
+          expect(page).to have_field(
+            'Imagem',
+            with: 'https://s3-sa-east-1.amazonaws.com/deliveryon-uploads/products/imperio/38_5c58b562c06f5.jpg',
+            placeholder: 'Imagem'
+          )
+          expect(page).to have_field('Ingredientes', with: '', placeholder: 'Digite um ingrediente')
+          expect(page).to have_button('Incluir', disabled: true)
+          within '.chips-container' do
+            expect(page).to have_content("Fruta\n×")
+          end
+          toggle_active_product = find_field('Produto ativo', type: 'checkbox', visible: false)
+          expect(toggle_active_product).to be_checked
+          toggle_featured_product = find_field('Produto em destaque', type: 'checkbox', visible: false)
+          expect(toggle_featured_product).not_to be_checked
+        end
+
+        expect(page).to have_button('Continuar', disabled: true)
+        expect(page).not_to have_css('.cancel', text: 'Voltar')
+      end
     end
 
     it 'and see errors in all required fields after touched' do
@@ -50,6 +201,19 @@ describe 'User view product form', type: :system do
       expect(page).to have_content 'Tempo de preparo é obrigatório'
       expect(page).to have_content 'Descrição é obrigatória'
       expect(page).not_to have_content 'Imagem do produto é obrigatório'
+    end
+
+    it 'and see quick template after valid fields' do
+      fill_first_step
+
+      expect(page).to have_content 'Seu produto tem opções?'
+      expect(page).to have_content 'Modificadores permitem que seus clientes personalizem o produto. Por exemplo:'
+      expect(page).to have_content "Pizza\nTamanhos, sabores, bordas"
+      expect(page).to have_content "Açaí\nComplementos, frutas, coberturas"
+      expect(page).to have_content "Hambúrguer\nAdicionais, molhos, ponto da carne"
+      expect(page).to have_content "Bebidas\nTamanhos, temperaturas"
+      expect(page).to have_button 'Sim, adicionar opções'
+      expect(page).to have_button 'Não, produto simples'
     end
   end
 


### PR DESCRIPTION
Esse PR fecha a issue #13 

## Descrição

Este PR implementa o **fluxo completo de criação de produtos** na aplicação, incluindo ajustes no frontend, suporte no backend e testes completos de sistema e modelo.

## Frontend

- Refatoração do `ProductForm.vue` para lidar com preenchimento dinâmico de ingredientes e grupos de modificadores.
- Ajustes no composable `useProductForm` para atribuir corretamente os dados do template ao produto, evitando sobrescrita de ingredientes.
- Renomeação consistente de `modifiers_groups` para `modifier_groups` em todos os componentes.
- Melhorias na interface:
  - Correção de placeholders do input de ingredientes.
  - Ajuste da lógica de toggles para produto ativo e produto em destaque.
  - Validação de categoria corrigida no `ProductValidator`.

## Backend / API

- Modelos `Product` `ModifierGroup` e `Modifier` atualizados para alinhar com alterações do frontend.
- Rotas da API adicionadas para produtos e categorias (`ProductsController#create` e `CategoriesController#index`).

## Testes

- Testes de **sistema** adicionados para:
  - Visualizar o formulário de criação de produto.
  - Usar templates rápidos (Pizza, Hambúrguer, Açaí, Bebida).
  - Criar produto com ou sem grupos de modificadores.
  - Lidar com erros do servidor durante a criação de produto.
- Testes de **modelos** adicionados para:
  - `Product`, `ModifierGroup` e `Modifier`.
- Testes de **request** adicionados para:
  - `POST /api/v1/products`
- **Factories** adicionados para `Product`, `ModifierGroup` e `Modifier`.

## I18n

- Adicionadas traduções `pt-BR` para produtos, grupos e modificadores, além de algumas mensagens para validações do `ModifierGroup`.

## Observações

- Váriaveis relacionados a modificadores no frontend foram renomeados de `modifiers` / `modifiers_groups` para `modifiers_attributes` / `modifier_groups` para garantir binding correto e consistência para inserção por meio do `accepts_nested_attributes_for` do Rails.
- O fluxo suporta produtos simples e produtos com múltiplos grupos de modificadores.
- Templates rápidos permitem preenchimento automático para acelerar a criação de produtos.

---

**Próximos passos / considerações:**

- Avaliar adição de mais templates rápidos para outros tipos de grupos de modificadores.
