### PR TITLE
Feature: exibe categorias do restaurante

### DIFF
--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -1,3 +1,5 @@
 class MenusController < ApplicationController
-  def show; end
+  def show
+    @categories = current_restaurant_user.restaurant.categories.with_products_stats
+  end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -29,7 +29,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const menuEl = document.getElementById('menu-widget')
   if (menuEl) {
-    createApp(Menu).mount(menuEl)
+    const categoriesData = JSON.parse(menuEl.dataset.categories);
+
+    createApp(Menu, { categories: categoriesData }).mount(menuEl)
   }
 
   const newPro = document.getElementById('new-product')

--- a/app/javascript/components/category/CategoriesCard.vue
+++ b/app/javascript/components/category/CategoriesCard.vue
@@ -1,0 +1,149 @@
+<template>
+  <div class="category-card">
+    <div class="category-info">
+      <div class="category-header">
+        <span class="category-title">{{ category.name }}</span>
+        <div class="box-icon">
+          <Icon icon="lucide:package" />
+        </div>
+      </div>
+      <div class="category-stats">
+        <div class="stat-item">
+          <span class="stat-label">Produtos</span>
+          <ItemChip :item="category.products_count" class="stat-value" />
+        </div>
+        <div class="stat-item">
+          <span class="stat-label">Ativos</span>
+          <ItemChip :item="category.actived_products_count" class="stat-value active" />
+        </div>
+        <div class="stat-item">
+          <span class="stat-label">Preço Médio</span>
+          <span>{{ FloatToMoney(category.average_price) }}</span>
+        </div>
+      </div>
+    </div>
+    <div class="category-actions">
+      <AppButton class="edit-btn" text="Editar" iconLeft="lucide-pen-line" />
+      <AppButton class="delete-btn" iconLeft="lucide:trash-2" />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { defineProps } from 'vue';
+import { Icon } from '@iconify/vue';
+import AppButton from '../ui/AppButton.vue';
+import ItemChip from '../ui/ItemChip.vue'
+import { FloatToMoney } from '../../utils/modey';
+
+
+defineProps({
+  category: {
+    type: Object,
+    required: true,
+    default: () => ({
+      name: '',
+      productsCount: 0,
+      activeProductsCount: 0,
+    }),
+  },
+});
+</script>
+
+<style scoped>
+.category-card {
+  background: var(--color-white);
+  border-radius: 8px;
+  transition: transform 0.2s, box-shadow 0.3s;
+  border: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  cursor: pointer;
+  height: 300px;
+  padding: 1.5rem;
+}
+
+.category-card:hover {
+  box-shadow: var(--shadow-md);
+}
+
+.category-header {
+  display: flex;
+  margin-bottom: 1rem;
+}
+
+.category-title {
+  font-size: 1.25rem;
+  font-weight: bold;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}
+
+.box-icon svg {
+  width: 2.5rem;
+  height: 2.5rem;
+  color: var(--color-text-light);
+}
+
+.category-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.stat-item {
+  background: var(--color-background);
+  padding: 0.7rem 1rem;
+  border-radius: 4px;
+  display: flex;
+  justify-content: space-between;
+}
+
+.stat-label {
+  font-size: 1rem;
+  font-weight: 500;
+}
+
+.stat-value {
+  font-size: 0.9rem;
+  font-weight: bold;
+}
+
+.stat-value.active {
+  background-color: var(--color-success);
+  color: var(--color-white);
+}
+
+.category-actions {
+  display: flex;
+  gap: 1rem;
+}
+
+.edit-btn {
+  border: 1px solid var(--color-border);
+  background: var(--color-white);
+  color: var(--color-black);
+  width: 100%;
+}
+
+.edit-btn:hover {
+  background-color: var(--color-border);
+}
+
+.delete-btn {
+  border: 1px solid var(--color-border);
+  background: var(--color-white);
+  color: var(--color-primary);
+}
+
+.delete-btn :deep(svg) {
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+.delete-btn:hover {
+  background: var(--color-border);
+}
+</style>

--- a/app/javascript/components/menu/MenuCenter.vue
+++ b/app/javascript/components/menu/MenuCenter.vue
@@ -12,7 +12,13 @@
 
       <div v-show="tab === 'categories'">
         <CategoriesFilter @openCategoryModal="openCategoryForm"/>
-        <MenuEmptyState @openCategoryModal="openCategoryForm" />
+        <div v-if="categories.length > 0" class="categories-container">
+          <CategoriesCard
+            v-for="category in categories"
+            :category="category"
+          />
+        </div>
+        <MenuEmptyState v-else @openCategoryModal="openCategoryForm"  />
       </div>
     </div>
   </div>
@@ -30,6 +36,11 @@ import TabMenu from './TabMenu.vue'
 import CategoriesFilter from './CategoriesFilter.vue'
 import CategoryFormModal from '../category/CategoryFormModal.vue'
 import { navigateTo } from '../../utils/navigation'
+import CategoriesCard from '../category/CategoriesCard.vue'
+
+defineProps({
+  categories: Object
+})
 
 const tab = ref('products')
 
@@ -66,6 +77,27 @@ function handleTabChange(view) {
   background-color: var(--color-background);
   margin: 0 2rem;
   width: 1820px;
+}
+
+.categories-container {
+  display: grid;
+  gap: 2rem;
+  margin: 2rem auto;
+  padding: 0 1rem;
+  grid-template-columns: repeat(1, 1fr);
+}
+
+ @media (min-width: 758px) {
+  .categories-container {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1250px) {
+  .categories-container {
+    grid-template-columns: repeat(3, 1fr);
+    margin: 3rem auto;
+  }
 }
 
 .tab {

--- a/app/javascript/components/menu/MenuEmptyState.vue
+++ b/app/javascript/components/menu/MenuEmptyState.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="empty-box">
     <Icon icon="tabler:package" class="empty-icon" />
-    <p class="empty-text">Nenhum {{ product ? 'produtos' : 'categorias' }} encontrado</p>
+    <p class="empty-text">{{ product ? 'Nenhum produto encontrado' : 'Nenhuma categoria encontrada' }} </p>
     <p class="empty-subtext">Comece adicionando {{ product ? 'seu primeiro produto' : 'sua primeira categoria' }}</p>
     <AppButton
       iconLeft="tabler:plus"

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,5 +1,18 @@
 class Category < ApplicationRecord
   belongs_to :restaurant
+  has_many :products
+
+  scope :with_products_stats, -> {
+    left_joins(:products)
+      .select(
+        "categories.id,
+         categories.name,
+         COUNT(products.id) AS products_count,
+         SUM(CASE WHEN products.status = #{Product.statuses[:active]} THEN 1 ELSE 0 END) AS actived_products_count,
+         COALESCE(AVG(products.base_price), 0) AS average_price"
+      )
+      .group("categories.id")
+  }
 
   validates :name, presence: true
 end

--- a/app/views/menus/show.html.erb
+++ b/app/views/menus/show.html.erb
@@ -1,1 +1,1 @@
-<div id="menu-widget"></div>
+<div id="menu-widget" data-categories="<%= @categories.to_json %>"></div>

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -17,4 +17,20 @@ RSpec.describe Category, type: :model do
       expect(category.errors.full_messages).not_to include("Descrição não pode ficar em branco")
     end
   end
+
+  context '.with_products_stats' do
+    let(:category) { create(:category, restaurant:) }
+    let(:active_product) { create(:product, category:, status: :active, base_price: 100, restaurant:) }
+    let(:inactive_product) { create(:product, category:, status: :inactive, base_price: 200, restaurant:) }
+
+    it 'returns the category with correct count and average' do
+      active_product
+      inactive_product
+      result = Category.with_products_stats.find(category.id)
+
+      expect(result.products_count).to eq 2
+      expect(result.actived_products_count).to eq 1
+      expect(result.average_price.to_f).to eq 150
+    end
+  end
 end

--- a/spec/system/categories/user_views_category_list_spec.rb
+++ b/spec/system/categories/user_views_category_list_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+describe 'User views category list', type: :system do
+  let(:user) { create(:restaurant_user) }
+  let(:restaurant) { create(:restaurant, restaurant_user: user) }
+
+  it 'successfully' do
+    category = create(:category, restaurant:, name: 'Pizzas')
+    create(:product, category:, status: :active, base_price: 1000, restaurant:)
+    create(:product, category:, status: :inactive, base_price: 2000, restaurant:)
+    login_as user
+    visit root_path
+    find('span', text: 'Gerenciar Menu').click
+    find('span', text: 'Categorias').click
+
+    expect(page).to have_current_path(menu_path)
+    expect(page).to have_content('Gerenciar Categorias')
+    expect(page).to have_button('Nova Categoria')
+
+    within '.categories-container' do
+      expect(page).to have_content('Pizza')
+      expect(page).to have_content("Produtos\n2")
+      expect(page).to have_content("Ativos\n1")
+      expect(page).to have_content("Preço Médio\nR$ 15,00")
+      expect(page).to have_css('.edit-btn', text: 'Editar')
+      expect(page).to have_css('.delete-btn')
+    end
+  end
+
+  it 'but no categories' do
+    restaurant
+    login_as user
+    visit root_path
+    find('span', text: 'Gerenciar Menu').click
+    find('span', text: 'Categorias').click
+
+    expect(page).to have_current_path(menu_path)
+    expect(page).to have_content('Gerenciar Categorias')
+    expect(page).to have_button('Nova Categoria')
+    expect(page).to have_content('Nenhuma categoria encontrada')
+    expect(page).to have_content('Comece adicionando sua primeira categoria')
+    expect(page).to have_button('Adicionar Categorias')
+  end
+end


### PR DESCRIPTION
Fecha issue #61 

## Descrição
Este PR implementa a funcionalidade de exibir as categorias de um restaurante na tela de menu. Inclui:

- Escopo `with_products_stats` no model `Category` para obter:
  - Total de produtos por categoria
  - Quantidade de produtos ativos por categoria
  - Preço médio dos produtos por categoria
- Atualização do `MenusController#show` para utilizar o escopo e passar os dados para a view
- Componente Vue `MenuCenter` atualizado para receber e exibir os dados das categorias
- Componente `CategoriesCard` para renderizar cada categoria em um layout responsivo em grid
- Specs de sistema e model para verificar a exibição das categorias e estatísticas dos produtos

## Detalhes de Implementação
- As queries do backend são otimizadas usando um único `left_joins` com agregações SQL (`COUNT`, `SUM`, `AVG`) para evitar N+1 queries.
- Frontend lê os dados JSON do atributo `data-categories` e os passa como prop para os componentes Vue.
- Layout responsivo adicionado ao grid para suportar diferentes tamanhos de tela.

## Testes
- Spec de model testa o escopo `with_products_stats` para verificar contagens e média corretas.
- Spec de sistema verifica que o usuário consegue visualizar a lista de categorias no menu.

## Telas da funcionalidade

### Desktop
<img width="1831" height="1015" alt="image" src="https://github.com/user-attachments/assets/03b35b83-9ef5-4e28-aad2-2b08ebe61fc9" />

### Mobile
<img width="384" height="836" alt="image" src="https://github.com/user-attachments/assets/6c7cdd0b-f9f5-4c10-98f8-9c1afba1637d" />
