### PR TITLE
feat(category): limit number of categories per restaurant

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -5,6 +5,8 @@ class Category < ApplicationRecord
   validates :name, presence: true
   validates :name, uniqueness: { scope: :restaurant_id, case_sensitive: false }
 
+  validate :restaurant_category_limit
+
   scope :with_products_stats, -> {
     active_status = Product.statuses[:active]
 
@@ -19,4 +21,18 @@ class Category < ApplicationRecord
 
     left_joins(:products).select(select_clause).group("categories.id")
   }
+
+  MAX_CATEGORIES_PER_RESTAURANT = 10
+
+  private
+
+  def restaurant_category_limit
+    return if restaurant.nil?
+    return if restaurant.categories.count < MAX_CATEGORIES_PER_RESTAURANT
+    errors.add(
+      :base,
+      I18n.t("activerecord.errors.models.category.attributes.base.max_categories",
+             count: MAX_CATEGORIES_PER_RESTAURANT)
+    )
+  end
 end

--- a/config/locales/models/category.pt-BR.yml
+++ b/config/locales/models/category.pt-BR.yml
@@ -7,3 +7,10 @@ pt-BR:
         name: "Nome"
         description: "Descrição"
         restaurant: "Restaurante"
+        base:
+    errors:
+        models:
+          category:
+            attributes:
+              base:
+                max_categories: Você atingiu o limite de %{count} categorias. Edite ou exclua categorias existentes para adicionar novas.

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -23,6 +23,18 @@ RSpec.describe Category, type: :model do
       expect(category).not_to be_valid
       expect(category.errors.full_messages).to include("Nome já está em uso")
     end
+
+    it 'is invalid if the restaurant already has the maximum allowed categories' do
+      restaurant.categories.destroy_all
+      max_categories = 10
+      max_categories.times do |i|
+        create(:category, name: "Category #{i}", restaurant:)
+      end
+
+      category = Category.new(name: "Excesso", restaurant:)
+      expect(category).not_to be_valid
+      expect(category.errors.full_messages).to include("Você atingiu o limite de 10 categorias. Edite ou exclua categorias existentes para adicionar novas.")
+    end
   end
 
   context '.with_products_stats' do


### PR DESCRIPTION
Resolve issue #64 
### Descrição
Este PR adiciona uma validação no model `Category` para limitar o número de categorias que um restaurante pode criar.  
O limite definido é de **10 categorias** por restaurante.

Além disso:
- Mensagem de erro foi adicionada ao I18n (`pt-BR`).
- Adicionado teste de model para garantir que o limite seja respeitado.

### Mudanças principais
- `Category`:
  - Validação `restaurant_category_limit`.
  - Constante `MAX_CATEGORIES_PER_RESTAURANT = 10`.
- `config/locales/models/category.pt-BR.yml`:
  - Nova mensagem de erro para limite de categorias.
- `spec/models/category_spec.rb`:
  - Teste garantindo que não seja possível criar mais que 10 categorias por restaurante.

### Checklist
- [x] Mensagem de erro via I18n
- [x] Validação adicionada no model
- [x] Teste de model implementado
- [x] Código revisado e funcionando localmente

### Observações
Ao atingir o limite, o usuário verá a mensagem:
> "Você atingiu o limite de 10 categorias. Edite ou exclua categorias existentes para adicionar novas."
