### PR TITLE
(ci) Configure CI to run RSpec instead of Minitest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,16 +66,7 @@ jobs:
           - 5432:5432
         options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
 
-      # redis:
-      #   image: redis
-      #   ports:
-      #     - 6379:6379
-      #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
-
     steps:
-      - name: Install packages
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y build-essential git libpq-dev libyaml-dev pkg-config google-chrome-stable
-
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -85,17 +76,38 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
 
-      - name: Run tests
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+
+      - name: Install JavaScript dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y \
+            build-essential git libpq-dev libyaml-dev pkg-config \
+            chromium chromium-driver fonts-liberation libnss3 \
+            libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 \
+            libxi6 libxtst6 xdg-utils
+
+      - name: Precompile assets
+        run: bin/rails assets:precompile
+        env:
+          RAILS_ENV: test
+
+      - name: Prepare database
         env:
           RAILS_ENV: test
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
-          # REDIS_URL: redis://localhost:6379/0
-        run: bin/rails db:test:prepare test test:system
+        run: |
+          bin/rails db:create db:schema:load
 
-      - name: Keep screenshots from failed system tests
-        uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: screenshots
-          path: ${{ github.workspace }}/tmp/screenshots
-          if-no-files-found: ignore
+      - name: Run RSpec tests
+        env:
+          RAILS_ENV: test
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432
+        run: bundle exec rspec

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,6 +22,9 @@ Capybara.register_driver :selenium_chrome_headless do |app|
     opts.add_argument("--user-data-dir=/tmp/test-profile-#{SecureRandom.uuid}")
   end
 
+  chrome_path = '/usr/bin/chromium-browser'
+  chrome_options.binary = chrome_path if File.exist?(chrome_path)
+
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: chrome_options)
 end
 
@@ -40,6 +43,7 @@ RSpec.configure do |config|
 
   config.before(:each, type: :system) do
     driven_by :selenium_chrome_headless
+    Capybara.server = :puma, { Silent: true }
   end
 
   config.include Warden::Test::Helpers


### PR DESCRIPTION
### Descrição

Este PR atualiza o workflow de CI para:

- Configurar o CI para rodar **RSpec** ao invés de Minitest.
- Adicionar suporte `chrome_options.binary` ao **Capybara** para testes de sistema.
- Corrigir o caminho do **Chrome** para execução no GitHub Actions.
- Configurar a criação do banco de dados e carregamento do schema antes dos testes.
- Instalar Node e Yarn.
- Precompilar os assets antes de rodar os testes para evitar erros de assets missing.

Com estas alterações, todos os testes passam a rodar de forma confiável no CI.
