### PR TITLE
Featur: endpoints para busca de produtos restaurantes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,8 @@ gem "jsbundling-rails", "~> 1.3"
 
 gem "devise"
 
+gem "kaminari"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,18 @@ GEM
       sshkit (>= 1.23.0, < 2.0)
       thor (~> 1.3)
       zeitwerk (>= 2.6.18, < 3.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.5)
     launchy (3.1.0)
       addressable (~> 2.8)
@@ -429,6 +441,7 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails (~> 1.3)
   kamal
+  kaminari
   launchy
   pg (~> 1.1)
   propshaft

--- a/app/controllers/api/v1/products_controller.rb
+++ b/app/controllers/api/v1/products_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::ProductsController < Api::V1::ApplicationController
+  include ProductsJson
+
   def create
     product = Product.new(product_params)
 
@@ -20,7 +22,26 @@ class Api::V1::ProductsController < Api::V1::ApplicationController
     end
   end
 
+  def index
+    products = ProductQuery.new(params).call
+
+    render json: {
+      products: products_json(full: params[:full] == "true",
+        collection: products
+      ),
+      meta: pagination_meta(products)
+    }, status: :ok
+  end
+
   private
+
+  def pagination_meta(scope)
+    {
+      current_page: scope.current_page,
+      total_pages: scope.total_pages,
+      total_count: scope.total_count
+    }
+  end
 
   def product_params
     params.require(:product).permit(

--- a/app/controllers/api/v1/restaurants_controller.rb
+++ b/app/controllers/api/v1/restaurants_controller.rb
@@ -28,11 +28,28 @@ class Api::V1::RestaurantsController < Api::V1::ApplicationController
   end
 
   def index
-    @restaurants = restaurants_json(full: params[:full] == "true")
-    render json: @restaurants
+    restaurants = RestaurantQuery.new(params).call
+
+    filtered = restaurants.joins(:products).distinct
+
+    render json: {
+      restaurants: restaurants_json(
+        full: params[:full] == "true",
+        collection: filtered
+      ),
+      meta: pagination_meta(filtered)
+    }
   end
 
   private
+
+  def pagination_meta(collection)
+    {
+      current_page: collection.current_page,
+      total_pages: collection.total_pages,
+      total_count: collection.total_count
+    }
+  end
 
   def set_restaurant
     @restaurant = Restaurant.find(params[:id])

--- a/app/controllers/concerns/product_json.rb
+++ b/app/controllers/concerns/product_json.rb
@@ -1,0 +1,43 @@
+module ProductJson
+  extend ActiveSupport::Concern
+
+  def product_json(product)
+    {
+      id: product.id,
+      restaurant_id: product.restaurant_id,
+      name: product.name,
+      duration: product.duration,
+      base_price: product.base_price,
+      description: product.description,
+      image: product.image,
+      category: product.category.name,
+      featured: product.featured,
+      modifier_groups: product.modifier_groups.map { |group| modifier_group_json(group) }
+    }
+  end
+
+  private
+
+  def modifier_group_json(group)
+    {
+      id: group.id,
+      product_id: group.product_id,
+      name: group.name,
+      input_type: group.input_type,
+      min: group.min,
+      max: group.max,
+      free_limit: group.free_limit,
+      modifiers: group.modifiers.map { |modifier| modifier_json(modifier) }
+    }
+  end
+
+  def modifier_json(modifier)
+    {
+      id: modifier.id,
+      modifier_group_id: modifier.modifier_group_id,
+      name: modifier.name,
+      base_price: modifier.base_price,
+      image: modifier.image
+    }
+  end
+end

--- a/app/controllers/concerns/products_json.rb
+++ b/app/controllers/concerns/products_json.rb
@@ -1,0 +1,23 @@
+module ProductsJson
+  extend ActiveSupport::Concern
+  include ProductJson
+
+  def products_json(full: false, collection: nil)
+    collection ||= Product.all
+
+    collection.map do |product|
+      if full
+        product_json(product)
+      else
+        {
+          id: product.id,
+          restaurant_id: product.restaurant_id,
+          name: product.name,
+          description: product.description,
+          image: product.image,
+          base_price: product.base_price
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/restaurant_json.rb
+++ b/app/controllers/concerns/restaurant_json.rb
@@ -1,5 +1,6 @@
 module RestaurantJson
   extend ActiveSupport::Concern
+  include ProductJson
 
   def restaurant_json(restaurant)
     {
@@ -25,44 +26,6 @@ module RestaurantJson
       id: category.id,
       name: category.name,
       products: category.products.active.map { |product| product_json(product) }
-    }
-  end
-
-  def product_json(product)
-    {
-      id: product.id,
-      restaurant_id: product.restaurant_id,
-      name: product.name,
-      duration: product.duration,
-      base_price: product.base_price,
-      description: product.description,
-      image: product.image,
-      category: product.category.name,
-      featured: product.featured,
-      modifier_groups: product.modifier_groups.map { |group| modifier_group_json(group) }
-    }
-  end
-
-  def modifier_group_json(group)
-    {
-      id: group.id,
-      product_id: group.product_id,
-      name: group.name,
-      input_type: group.input_type,
-      min: group.min,
-      max: group.max,
-      free_limit: group.free_limit,
-      modifiers: group.modifiers.map { |modifier| modifier_json(modifier) }
-    }
-  end
-
-  def modifier_json(modifier)
-    {
-      id: modifier.id,
-      modifier_group_id: modifier.modifier_group_id,
-      name: modifier.name,
-      base_price: modifier.base_price,
-      image: modifier.image
     }
   end
 end

--- a/app/controllers/concerns/restaurants_json.rb
+++ b/app/controllers/concerns/restaurants_json.rb
@@ -2,16 +2,17 @@ module RestaurantsJson
   extend ActiveSupport::Concern
   include RestaurantJson
 
-  def restaurants_json(full: false)
-    restaurants = Restaurant.joins(:products).distinct.order(:id)
+  def restaurants_json(full: false, collection: nil)
+    collection ||= Restaurant.all
 
-    restaurants.map do |restaurant|
+    collection.map do |restaurant|
       if full
         restaurant_json(restaurant)
       else
         {
           id: restaurant.id,
           name: restaurant.name,
+          description: restaurant.description,
           logo: restaurant.image
         }
       end

--- a/app/queries/product_query.rb
+++ b/app/queries/product_query.rb
@@ -1,0 +1,40 @@
+class ProductQuery
+  def initialize(params)
+    @params = params
+  end
+
+  def call
+    scope = Product.includes(:category, :restaurant).distinct.order(:id)
+
+    scope = filter_by_query(scope)
+    scope = filter_by_category(scope)
+    scope = paginate(scope)
+
+    scope
+  end
+
+  private
+
+  def filter_by_query(scope)
+    return scope unless @params[:query].present?
+
+    query = "%#{@params[:query]}%"
+    scope.where("products.name ILIKE :query OR
+                 products.description ILIKE :query OR
+                array_to_string(products.ingredients, ',') ILIKE :query",
+                query:
+                ).distinct
+  end
+
+  def filter_by_category(scope)
+    return scope unless @params[:category].present?
+
+    query = "%#{@params[:category]}%"
+    scope.joins(:category)
+         .where("LOWER(categories.name) ILIKE :query", query:)
+  end
+
+  def paginate(scope)
+    scope.page(@params[:page]).per(@params[:per_page] || 10)
+  end
+end

--- a/app/queries/restaurant_query.rb
+++ b/app/queries/restaurant_query.rb
@@ -1,0 +1,46 @@
+class RestaurantQuery
+  def initialize(params)
+    @params = params
+  end
+
+  def call
+    scope = Restaurant.includes(:products, :categories).distinct.order(:id)
+
+    scope = filter_by_query(scope)
+    scope = filter_by_category(scope)
+    scope = paginate(scope)
+
+    scope
+  end
+
+  private
+
+  def filter_by_query(scope)
+    return scope unless @params[:query].present?
+
+    query = "%#{@params[:query]}%"
+    scope.left_joins(:products)
+        .where(
+          "restaurants.name ILIKE :query OR
+          restaurants.description ILIKE :query OR
+          products.name ILIKE :query OR
+          products.description ILIKE :query OR
+          array_to_string(products.ingredients, ',') ILIKE :query",
+          query:
+        )
+        .distinct
+  end
+
+  def filter_by_category(scope)
+    return scope unless @params[:category].present?
+
+    category_name = "%#{@params[:category]}%"
+    scope.joins(products: :category)
+         .where("categories.name ILIKE :category", category: category_name)
+         .distinct
+  end
+
+  def paginate(scope)
+    scope.page(@params[:page]).per(@params[:per_page] || 10)
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,7 @@ module DeliDropApp
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.autoload_paths << Rails.root.join('app/queries')
+    config.eager_load_paths << Rails.root.join('app/queries')
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,7 @@ module DeliDropApp
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
-    config.autoload_paths << Rails.root.join('app/queries')
-    config.eager_load_paths << Rails.root.join('app/queries')
+    config.autoload_paths << Rails.root.join("app/queries")
+    config.eager_load_paths << Rails.root.join("app/queries")
   end
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,7 +1,7 @@
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     origins [ ENV.fetch("FRONTEND_HOST"), "http://localhost:5173" ]
-    resource "/api/v1/restaurants/*",
+    resource "/api/v1/*",
     headers: :any,
     methods: [ :get, :options, :head ],
     credentials: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :restaurants, only: %i[create update show index]
       resources :categories, only: %i[index create update]
-      resources :products, only: %i[create update]
+      resources :products, only: %i[create update index]
     end
   end
 

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -1,14 +1,15 @@
 FactoryBot.define do
   factory :product do
     name { "Combo Mix" }
-    category { nil }
     base_price { 4990 }
     description { "Este é o combo mais conhecido do mundo" }
     ingredients { [ "Bebidas", "Comidas" ] }
     status { 'active' }
     featured { false }
-    restaurant { nil }
     duration { 34 }
     image { "http://product_image.png" }
+
+    association :restaurant, factory: :restaurant
+    category { association(:category, restaurant: restaurant) }
   end
 end

--- a/spec/factories/restaurants.rb
+++ b/spec/factories/restaurants.rb
@@ -6,6 +6,6 @@ FactoryBot.define do
     image { "http://imagem.com" }
     phone { "89 99999-9999" }
     address { "Rua das Palmeiras, 400" }
-    restaurant_user { nil }
+    association :restaurant_user, factory: :restaurant_user
   end
 end

--- a/spec/queries/product_query_spec.rb
+++ b/spec/queries/product_query_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe ProductQuery do
+  describe '#call' do
+    it 'returns all products when there are no filters' do
+      product1 = create(:product)
+      product2 = create(:product)
+      product3 = create(:product)
+
+      response = described_class.new({}).call
+
+      expect(response).to match_array([ product1, product2, product3 ])
+    end
+
+    context 'returns products whose' do
+      it 'product name matches the query' do
+        product1 = create(:product, name: 'Pizza de Calabresa')
+        create(:product, name: 'Pizza')
+
+        response = described_class.new({ query: 'Calabresa' }).call
+
+        expect(response).to contain_exactly(product1)
+      end
+
+      it 'product description matches the query' do
+        product1 = create(:product, description: 'Deliciosa Pizza de Calabresa')
+        create(:product, description: 'Deliciosa Pizza')
+
+        response = described_class.new({ query: 'Calabresa' }).call
+
+        expect(response).to contain_exactly(product1)
+      end
+
+      it 'product ingredients matches the query' do
+        product1 = create(:product, ingredients: [ 'Molho Italiano', 'Calabresa' ])
+        create(:product, ingredients: [ 'Cream Cheese', 'Cebola' ])
+
+        response = described_class.new({ query: 'Calabresa' }).call
+
+        expect(response).to contain_exactly(product1)
+      end
+    end
+
+    it 'return products by its category' do
+      restaurant = create(:restaurant)
+      product1 = create(:product, name: 'Pizza', restaurant:)
+      product2 = create(:product, name: 'Sushi',
+                                  category: create(:category, name: 'Japonesa', restaurant:))
+
+      response = described_class.new({ category: 'Japone' }).call
+
+      expect(response).to contain_exactly(product2)
+    end
+
+    it 'returns the items on the correct page when pagination is present' do
+      products = create_list(:product, 25)
+
+      response = described_class.new({ page: 2, per_page: 10 }).call
+
+      expect(response.current_page).to eq(2)
+      expect(response.size).to eq(10)
+      expect(response.total_count).to eq(25)
+    end
+  end
+end

--- a/spec/queries/restaurant_query_spec.rb
+++ b/spec/queries/restaurant_query_spec.rb
@@ -1,0 +1,106 @@
+require 'rails_helper'
+
+RSpec.describe RestaurantQuery do
+  describe '#call' do
+    it 'returns all restaurants when there are no filters' do
+      restaurant1 = create(:restaurant, name: 'Pizzaria Dony')
+      restaurant2 = create(:restaurant, name: 'Sushi Place')
+      restaurant3 = create(:restaurant, name: 'Hamburgueria 123')
+
+      create(:product, restaurant: restaurant1, category: restaurant1.categories.first)
+      create(:product, restaurant: restaurant2, category: restaurant2.categories.first)
+      create(:product, restaurant: restaurant3, category: restaurant3.categories.first)
+
+      response = described_class.new({}).call
+
+      expect(response).to match_array([ restaurant1, restaurant2, restaurant3 ])
+    end
+
+    context 'returns restaurants whose' do
+      it 'restaurant name matches the query' do
+        restaurant1 = create(:restaurant, name: 'Pizzaria Dony')
+        restaurant2 = create(:restaurant, name: 'Sushi Place')
+
+        create(:product, restaurant: restaurant1, category: restaurant1.categories.first)
+        create(:product, restaurant: restaurant2, category: restaurant2.categories.first)
+
+        response = described_class.new({ query: 'piz' }).call
+
+        expect(response).to contain_exactly(restaurant1)
+      end
+
+      it 'restaurant description matches the query' do
+        restaurant1 = create(:restaurant, description: 'Pizza artesanal')
+        restaurant2 = create(:restaurant, description: 'Comida japonesa')
+
+        create(:product, restaurant: restaurant1, category: restaurant1.categories.first)
+        create(:product, restaurant: restaurant2, category: restaurant2.categories.first)
+
+        response = described_class.new({ query: 'piz' }).call
+
+        expect(response).to contain_exactly(restaurant1)
+      end
+
+      it 'product name matches the query' do
+        restaurant1 = create(:restaurant)
+        restaurant2 = create(:restaurant)
+
+        create(:product, name: 'Pizza de Calabresa', restaurant: restaurant1, category: restaurant1.categories.first)
+        create(:product, name: 'Pizza', restaurant: restaurant2, category: restaurant2.categories.first)
+
+        response = described_class.new({ query: 'Calabresa' }).call
+
+        expect(response).to contain_exactly(restaurant1)
+      end
+
+      it 'product description matches the query' do
+        restaurant1 = create(:restaurant)
+        restaurant2 = create(:restaurant)
+
+        create(:product, description: 'Deliciosa Pizza de Calabresa', restaurant: restaurant1, category: restaurant1.categories.first)
+        create(:product, description: 'Deliciosa Pizza', restaurant: restaurant2, category: restaurant2.categories.first)
+
+        response = described_class.new({ query: 'Calabresa' }).call
+
+        expect(response).to contain_exactly(restaurant1)
+      end
+
+      it 'product ingredients matches the query' do
+        restaurant1 = create(:restaurant)
+        restaurant2 = create(:restaurant)
+
+        create(:product, ingredients: [ 'Molho Italiano', 'Calabresa' ], restaurant: restaurant1, category: restaurant1.categories.first)
+        create(:product, ingredients: [ 'Cream Cheese', 'Cebola' ], restaurant: restaurant2, category: restaurant2.categories.first)
+
+        response = described_class.new({ query: 'Calabresa' }).call
+
+        expect(response).to contain_exactly(restaurant1)
+      end
+    end
+
+    it 'returns restaurants by product category' do
+      restaurant1 = create(:restaurant, name: 'Pizzaria Dony')
+      restaurant2 = create(:restaurant, name: 'Sushi Place')
+
+      category = create(:category, name: 'Japonesa', restaurant: restaurant1)
+      create(:product, restaurant: restaurant2, category: category)
+
+      response = described_class.new({ category: 'Japone' }).call
+
+      expect(response).to contain_exactly(restaurant2)
+    end
+
+    it 'returns the items on the correct page when pagination is present' do
+      restaurants = create_list(:restaurant, 25)
+      restaurants.each do |restaurant|
+        create(:product, restaurant:, category: restaurant.categories.first)
+      end
+
+      response = described_class.new({ page: 2, per_page: 10 }).call
+
+      expect(response.current_page).to eq(2)
+      expect(response.size).to eq(10)
+      expect(response.total_count).to eq(25)
+    end
+  end
+end

--- a/spec/requests/api/v1/products/index_products_spec.rb
+++ b/spec/requests/api/v1/products/index_products_spec.rb
@@ -1,0 +1,161 @@
+require 'rails_helper'
+
+RSpec.describe "Products API" do
+  describe "GET api/v1/products/" do
+    context "returns products" do
+      include ProductJson
+       context "without params" do
+        it "returns only id, restaurant_id, name, description, image and base_price" do
+          product1 = create(:product, name: 'Product 1', description: 'The product 1',
+                                      image: 'http://www.product1.com', base_price: 2000)
+          product2 = create(:product, name: 'Product 2', description: 'The product 2',
+                                      image: 'http://www.product2.com', base_price: 3000)
+          product3 = create(:product, name: 'Product 3', description: 'The product 3',
+                                      image: 'http://www.product3.com', base_price: 4000)
+
+          get api_v1_products_path
+
+          expect(response).to have_http_status(:ok)
+
+          json_response = JSON.parse(response.body)
+          json_product1 = json_response['products'].first
+          json_product2 = json_response['products'].second
+          json_product3 = json_response['products'].third
+
+          expect(json_response["meta"]["current_page"]).to eq(1)
+          expect(json_response["meta"]["total_count"]).to eq(3)
+          expect(json_response["meta"]["total_pages"]).to eq(1)
+
+          expect(Product.count).to eq(3)
+          expect(json_response['products'].size).to eq(3)
+          expect(json_product1["id"]).to eq(product1.id)
+          expect(json_product1["restaurant_id"]).to eq(product1.restaurant_id)
+          expect(json_product1["name"]).to eq('Product 1')
+          expect(json_product1["description"]).to eq('The product 1')
+          expect(json_product1["image"]).to eq('http://www.product1.com')
+          expect(json_product1["base_price"]).to eq(2000)
+
+          expect(json_product2["id"]).to eq(product2.id)
+          expect(json_product2["restaurant_id"]).to eq(product2.restaurant_id)
+          expect(json_product2["name"]).to eq('Product 2')
+          expect(json_product2["description"]).to eq('The product 2')
+          expect(json_product2["image"]).to eq('http://www.product2.com')
+          expect(json_product2["base_price"]).to eq(3000)
+
+          expect(json_product3["id"]).to eq(product3.id)
+          expect(json_product3["restaurant_id"]).to eq(product3.restaurant_id)
+          expect(json_product3["name"]).to eq('Product 3')
+          expect(json_product3["description"]).to eq('The product 3')
+          expect(json_product3["image"]).to eq('http://www.product3.com')
+          expect(json_product3["base_price"]).to eq(4000)
+
+          json_products = json_response['products'].map(&:deep_symbolize_keys)
+          expect(json_products[0]).not_to eq(product_json(product1))
+          expect(json_products[1]).not_to eq(product_json(product2))
+          expect(json_products[2]).not_to eq(product_json(product3))
+        end
+      end
+
+      context "when it pass full=true" do
+        it "returns full product with modifiers_group and its modifiers" do
+          product1 = create(:product, name: 'Product 1', description: 'The product 1',
+                                      image: 'http://www.product1.com', base_price: 2000)
+          modifier_group1 = create(:modifier_group, product: product1)
+          create(:modifier, modifier_group: modifier_group1)
+          product2 = create(:product, name: 'Product 2', description: 'The product 2',
+                                      image: 'http://www.product2.com', base_price: 3000)
+          modifier_group2 = create(:modifier_group, product: product2)
+          create(:modifier, modifier_group: modifier_group2)
+          product3 = create(:product, name: 'Product 3', description: 'The product 3',
+                                      image: 'http://www.product3.com', base_price: 4000)
+          modifier_group3 = create(:modifier_group, product: product3)
+          create(:modifier, modifier_group: modifier_group3)
+
+          get api_v1_products_path, params: { full: true }
+
+          expect(response).to have_http_status(:ok)
+
+          json_response = JSON.parse(response.body)
+          json_product1 = json_response['products'].first
+          json_product2 = json_response['products'].second
+          json_product3 = json_response['products'].third
+
+          expect(json_response["meta"]["current_page"]).to eq(1)
+          expect(json_response["meta"]["total_count"]).to eq(3)
+          expect(json_response["meta"]["total_pages"]).to eq(1)
+
+          expect(Product.count).to eq(3)
+          json_products = json_response['products'].map(&:deep_symbolize_keys)
+          expect(json_products[0]).to eq(product_json(product1))
+          expect(json_products[1]).to eq(product_json(product2))
+          expect(json_products[2]).to eq(product_json(product3))
+        end
+      end
+
+      context "when filtering by query" do
+        it "returns products matching the name" do
+          product1 = create(:product, name: "Pizza de Calabresa")
+          create(:product, name: "Pizza Margherita")
+
+          get api_v1_products_path, params: { query: "Calabresa" }
+
+          json_response = JSON.parse(response.body)
+          expect(json_response['products'].size).to eq(1)
+          expect(json_response['products'].first['name']).to eq("Pizza de Calabresa")
+        end
+
+        it "returns products matching the description" do
+          product1 = create(:product, description: "Deliciosa Pizza de Calabresa")
+          create(:product, description: "Deliciosa Pizza")
+
+          get api_v1_products_path, params: { query: "Calabresa" }
+
+          json_response = JSON.parse(response.body)
+          expect(json_response['products'].size).to eq(1)
+          expect(json_response['products'].first['description']).to eq("Deliciosa Pizza de Calabresa")
+        end
+
+        it "returns products matching ingredients" do
+          product1 = create(:product, ingredients: ["Molho Italiano", "Calabresa"])
+          create(:product, ingredients: ["Cream Cheese", "Cebola"])
+
+          get api_v1_products_path, params: { query: "Calabresa" }
+
+          json_response = JSON.parse(response.body)
+          expect(json_response['products'].size).to eq(1)
+          expect(json_response['products'].first['id']).to eq(product1.id)
+        end
+      end
+
+      context "when filtering by category" do
+        it "returns products by category name" do
+          restaurant = create(:restaurant)
+          category = create(:category, name: "Japonesa", restaurant:)
+          product1 = create(:product, name: "Sushi", category: category, restaurant:)
+
+          create(:product, name: "Pizza", restaurant:)
+
+          get api_v1_products_path, params: { category: "Japone" }
+
+          json_response = JSON.parse(response.body)
+          expect(json_response['products'].size).to eq(1)
+          expect(json_response['products'].first['id']).to eq(product1.id)
+        end
+      end
+
+      context "pagination" do
+        it "returns the correct meta data" do
+          products = create_list(:product, 25)
+
+          get api_v1_products_path, params: { per_page: 10, page: 2 }
+
+          json_response = JSON.parse(response.body)
+          expect(json_response['products'].size).to eq(10)
+          expect(json_response['meta']['current_page']).to eq(2)
+          expect(json_response['meta']['total_pages']).to eq(3)
+          expect(json_response['meta']['total_count']).to eq(25)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/products/index_products_spec.rb
+++ b/spec/requests/api/v1/products/index_products_spec.rb
@@ -116,8 +116,8 @@ RSpec.describe "Products API" do
         end
 
         it "returns products matching ingredients" do
-          product1 = create(:product, ingredients: ["Molho Italiano", "Calabresa"])
-          create(:product, ingredients: ["Cream Cheese", "Cebola"])
+          product1 = create(:product, ingredients: [ "Molho Italiano", "Calabresa" ])
+          create(:product, ingredients: [ "Cream Cheese", "Cebola" ])
 
           get api_v1_products_path, params: { query: "Calabresa" }
 

--- a/spec/requests/api/v1/restaurants/index_restaurants_spec.rb
+++ b/spec/requests/api/v1/restaurants/index_restaurants_spec.rb
@@ -3,44 +3,61 @@ require 'rails_helper'
 RSpec.describe "Restaurants API", type: :request do
   describe "GET api/v1/restaurants/" do
     context 'returns only restaurants that have product(s)' do
-      context "when it doesn't pass full=true" do
-        it "returns only id, name and logo" do
+      include RestaurantJson
+      context "without params" do
+        it "returns only id, name, description and logo" do
           restaurant1 = create(:restaurant, restaurant_user: create(:restaurant_user),
-                              name: 'Restaurante 1', image: 'http://www.restaurant1.com')
+                              name: 'Restaurante 1', image: 'http://www.restaurant1.com',
+                              description: 'The restaurant 1')
           create(:product, restaurant: restaurant1, category: restaurant1.categories.first)
           restaurant2 = create(:restaurant, restaurant_user: create(:restaurant_user),
-                              name: 'Restaurante 2', image: 'http://www.restaurant2.com')
+                              name: 'Restaurante 2', image: 'http://www.restaurant2.com',
+                              description: 'The restaurant 2')
           create(:product, restaurant: restaurant2, category: restaurant1.categories.first)
           restaurant3 = create(:restaurant, restaurant_user: create(:restaurant_user),
-                              name: 'Restaurante 3', image: 'http://www.restaurant3.com')
+                              name: 'Restaurante 3', image: 'http://www.restaurant3.com',
+                              description: 'The restaurant 3')
           create(:product, restaurant: restaurant3, category: restaurant1.categories.first)
           restaurant4 = create(:restaurant, restaurant_user: create(:restaurant_user),
-                              name: 'Restaurante 4', image: 'http://www.restaurant4.com')
+                              name: 'Restaurante 4', image: 'http://www.restaurant4.com',
+                              description: 'The restaurant 4')
 
           get api_v1_restaurants_path
 
           expect(response).to have_http_status(:ok)
 
           json_response = JSON.parse(response.body)
-          json_restaurant1 = json_response.first
-          json_restaurant2 = json_response.second
-          json_restaurant3 = json_response.third
-          json_restaurant4 = json_response.fourth
+          json_restaurant1 = json_response['restaurants'].first
+          json_restaurant2 = json_response['restaurants'].second
+          json_restaurant3 = json_response['restaurants'].third
+          json_restaurant4 = json_response['restaurants'].fourth
 
-          expect(json_response.size).to eq(3)
+          expect(json_response["meta"]["current_page"]).to eq(1)
+          expect(json_response["meta"]["total_count"]).to eq(3)
+          expect(json_response["meta"]["total_pages"]).to eq(1)
+
+          expect(Restaurant.count).to eq(4)
+          expect(json_response['restaurants'].size).to eq(3)
           expect(json_restaurant1["id"]).to eq(restaurant1.id)
           expect(json_restaurant1["name"]).to eq('Restaurante 1')
+          expect(json_restaurant1["description"]).to eq('The restaurant 1')
           expect(json_restaurant1["logo"]).to eq('http://www.restaurant1.com')
 
           expect(json_restaurant2["id"]).to eq(restaurant2.id)
           expect(json_restaurant2["name"]).to eq('Restaurante 2')
+          expect(json_restaurant2["description"]).to eq('The restaurant 2')
           expect(json_restaurant2["logo"]).to eq('http://www.restaurant2.com')
 
           expect(json_restaurant3["id"]).to eq(restaurant3.id)
           expect(json_restaurant3["name"]).to eq('Restaurante 3')
+          expect(json_restaurant3["description"]).to eq('The restaurant 3')
           expect(json_restaurant3["logo"]).to eq('http://www.restaurant3.com')
 
           expect(json_restaurant4).to be_nil
+          json_restaurants = json_response['restaurants'].map(&:deep_symbolize_keys)
+          expect(json_restaurants[0]).not_to eq(restaurant_json(restaurant1))
+          expect(json_restaurants[1]).not_to eq(restaurant_json(restaurant2))
+          expect(json_restaurants[2]).not_to eq(restaurant_json(restaurant3))
         end
       end
 
@@ -58,27 +75,59 @@ RSpec.describe "Restaurants API", type: :request do
           expect(response).to have_http_status(:ok)
 
           json_response = JSON.parse(response.body)
-          json_restaurant = json_response.first
+          json_restaurant = json_response['restaurants'].first
 
-          expect(json_response.size).to eq(1)
-          expect(json_restaurant["id"]).to eq(restaurant.id)
-          expect(json_restaurant["name"]).to eq(restaurant.name)
-          expect(json_restaurant["logo"]).to eq(restaurant.image)
+          expect(json_response["meta"]["current_page"]).to eq(1)
+          expect(json_response["meta"]["total_count"]).to eq(1)
+          expect(json_response["meta"]["total_pages"]).to eq(1)
 
-          expect(json_restaurant["categories"]).to be_present
-          json_category = json_restaurant["categories"].first
-          expect(json_category["name"]).to eq("Pizzas")
+          expect(Restaurant.count).to eq(2)
+          json_restaurants = json_response['restaurants'].map(&:deep_symbolize_keys)
+          expect(json_restaurants[0]).to eq(restaurant_json(restaurant))
+        end
+      end
 
-          json_product = json_category["products"].first
-          expect(json_product["name"]).to eq("Pizza Margherita")
-          expect(json_product["base_price"]).to eq(30)
+      context "when restaurants have no products" do
+        it "does not return restaurants without products unless full=true" do
+          restaurant = create(:restaurant, restaurant_user: create(:restaurant_user))
 
-          json_group = json_product["modifier_groups"].first
-          expect(json_group["name"]).to eq("Sabores")
+          get api_v1_restaurants_path
+          json_response = JSON.parse(response.body)
 
-          json_modifier = json_group["modifiers"].first
-          expect(json_modifier["name"]).to eq("Extra queijo")
-          expect(json_modifier["base_price"]).to eq(5)
+          expect(json_response['restaurants']).to be_empty
+        end
+      end
+
+      context "when filtering by query" do
+        it "returns restaurants matching the query" do
+          r1 = create(:restaurant, name: "Pizza Place", restaurant_user: create(:restaurant_user))
+          r2 = create(:restaurant, name: "Burger Joint", restaurant_user: create(:restaurant_user))
+          create(:product, restaurant: r1, category: r1.categories.first)
+          create(:product, restaurant: r2, category: r2.categories.first)
+
+          get api_v1_restaurants_path, params: { query: "Pizza" }
+
+          json_response = JSON.parse(response.body)
+          expect(json_response['restaurants'].size).to eq(1)
+          expect(json_response['restaurants'].first['name']).to eq("Pizza Place")
+        end
+      end
+
+      context "pagination" do
+        it "returns the correct meta data" do
+          restaurants = create_list(:restaurant, 25)
+
+          restaurants.each do |restaurant|
+            create(:product, restaurant: restaurant, category: restaurant.categories.first)
+          end
+
+          get api_v1_restaurants_path, params: { per_page: 10, page: 2 }
+
+          json_response = JSON.parse(response.body)
+          expect(json_response['restaurants'].size).to eq(10)
+          expect(json_response['meta']['current_page']).to eq(2)
+          expect(json_response['meta']['total_pages']).to eq(3)
+          expect(json_response['meta']['total_count']).to eq(25)
         end
       end
     end


### PR DESCRIPTION
Fecha a issue #114 

## Descrição

**Objetivo:**  
Adicionar endpoints de busca para produtos e restaurantes na API, com suporte a filtros, paginação e retorno detalhado ou resumido.

## Alterações principais

### Produtos
- Criação do endpoint `GET /api/v1/products` para busca de produtos.
- Inclusão do concern `ProductsJson` e `ProductJson`  para serialização dos produtos.
- Implementação de `ProductQuery` para encapsular a lógica de filtragem para produtos.
- Paginação dos resultados com metadados (`current_page`, `total_pages`, `total_count`).

### Restaurantes
- Configuração no endpoint `GET /api/v1/restaurants` para suportar busca de restaurantes.
- Configuração do concern `RestaurantsJson` e uso do `RestaurantJson` para serialização detalhada.
- Implementação de `RestaurantQuery` para filtrar restaurantes com base em produtos, nome, descrição e categorias.
- Paginação dos resultados com metadados.

### Geral
- Adição da gem `kaminari` para paginação.
- Atualização de `config/application.rb` para autoload das queries.
- Ajuste do `cors.rb` para permitir acesso aos endpoints da API.
- Atualização das rotas para incluir `index` de produtos.
- Ajustes nas factories de produtos e restaurantes para suportar associações corretas.
- Specs de request adicionadas/atualizadas para testar comportamento da API, filtros e paginação.

## Observações
- Todos os endpoints seguem padrão de resposta JSON com chave `meta` para paginação e `restaurants`/`products` para dados.
- A ideia foi tornar a configuração e estrutura de `/api/v1/products` parecida com a `/api/v1/restaurants` em todo o seu fluxo de configuração, visando deixar o código mais padronizado para fácil manutenção.
