### PR TITLE
Feature: Adiciona categoria no JSON de produtos

### DIFF
--- a/app/controllers/concerns/products_json.rb
+++ b/app/controllers/concerns/products_json.rb
@@ -13,6 +13,7 @@ module ProductsJson
           id: product.id,
           restaurant_id: product.restaurant_id,
           name: product.name,
+          category: product.category.name,
           description: product.description,
           image: product.image,
           base_price: product.base_price

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -8,9 +8,20 @@ class Product < ApplicationRecord
   validates :name, :category, :base_price, :duration, :description, :status, presence: true
   validates :featured, inclusion: { in: [ true, false ] }
 
+  validate :category_belongs_to_same_restaurant
+
   enum :status, { active: 5, inactive: 10 }
 
-   scope :with_category_name, -> {
+  scope :with_category_name, -> {
     joins(:category).select("products.*, categories.name AS category_name")
   }
+
+  private
+
+  def category_belongs_to_same_restaurant
+    return if category.nil? || restaurant.nil?
+    if category.restaurant_id != restaurant_id
+      errors.add(:category, I18n.t("activerecord.errors.models.product.attributes.category.same_restaurant"))
+    end
+  end
 end

--- a/config/locales/models/product.pt-BR.yml
+++ b/config/locales/models/product.pt-BR.yml
@@ -14,3 +14,9 @@ pt-BR:
         featured: "Produto em Destaque"
         ingredients: Ingredientes
         restaurant: "Restaurante"
+    errors:
+      models:
+        product:
+          attributes:
+            category:
+              same_restaurant: deve pertencer ao mesmo restaurante que o produto

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -10,6 +10,6 @@ FactoryBot.define do
     image { "http://product_image.png" }
 
     association :restaurant, factory: :restaurant
-    category { association(:category, restaurant: restaurant) }
+    category { association(:category, restaurant:) }
   end
 end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -68,6 +68,16 @@ RSpec.describe Product, type: :model do
                             status: :active, featured: true)
       expect(product).to be_valid
     end
+
+    it "is invalid if product belongs to a different restaurant than its category" do
+      restaurant1 = create(:restaurant)
+      restaurant2 = create(:restaurant)
+      category = create(:category, restaurant: restaurant1)
+      product = Product.new(category: category, restaurant: restaurant2)
+
+      expect(product).not_to be_valid
+      expect(product.errors.full_messages).to include("Categoria deve pertencer ao mesmo restaurante que o produto")
+    end
   end
 
   context '.with_category_name' do

--- a/spec/queries/product_query_spec.rb
+++ b/spec/queries/product_query_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe ProductQuery do
     it 'return products by its category' do
       restaurant = create(:restaurant)
       product1 = create(:product, name: 'Pizza', restaurant:)
-      product2 = create(:product, name: 'Sushi',
+      product2 = create(:product, name: 'Sushi', restaurant:,
                                   category: create(:category, name: 'Japonesa', restaurant:))
 
       response = described_class.new({ category: 'Japone' }).call

--- a/spec/queries/restaurant_query_spec.rb
+++ b/spec/queries/restaurant_query_spec.rb
@@ -81,9 +81,8 @@ RSpec.describe RestaurantQuery do
     it 'returns restaurants by product category' do
       restaurant1 = create(:restaurant, name: 'Pizzaria Dony')
       restaurant2 = create(:restaurant, name: 'Sushi Place')
-
-      category = create(:category, name: 'Japonesa', restaurant: restaurant1)
-      create(:product, restaurant: restaurant2, category: category)
+      category = create(:category, name: 'Japonesa', restaurant: restaurant2)
+      create(:product, restaurant: restaurant2, category:)
 
       response = described_class.new({ category: 'Japone' }).call
 

--- a/spec/requests/api/v1/products/index_products_spec.rb
+++ b/spec/requests/api/v1/products/index_products_spec.rb
@@ -6,12 +6,21 @@ RSpec.describe "Products API" do
       include ProductJson
        context "without params" do
         it "returns only id, restaurant_id, name, description, image and base_price" do
+          restaurant = create(:restaurant)
+          category1 = create(:category, name: 'Category 1', restaurant:)
           product1 = create(:product, name: 'Product 1', description: 'The product 1',
-                                      image: 'http://www.product1.com', base_price: 2000)
+                                      image: 'http://www.product1.com', base_price: 2000,
+                                      category: category1, restaurant:)
+
+          category2 = create(:category, name: 'Category 2', restaurant:)
           product2 = create(:product, name: 'Product 2', description: 'The product 2',
-                                      image: 'http://www.product2.com', base_price: 3000)
+                                      image: 'http://www.product2.com', base_price: 3000,
+                                      category: category2, restaurant:)
+
+          category3 = create(:category, name: 'Category 3', restaurant:)
           product3 = create(:product, name: 'Product 3', description: 'The product 3',
-                                      image: 'http://www.product3.com', base_price: 4000)
+                                      image: 'http://www.product3.com', base_price: 4000,
+                                      category: category3, restaurant:)
 
           get api_v1_products_path
 
@@ -31,6 +40,7 @@ RSpec.describe "Products API" do
           expect(json_product1["id"]).to eq(product1.id)
           expect(json_product1["restaurant_id"]).to eq(product1.restaurant_id)
           expect(json_product1["name"]).to eq('Product 1')
+          expect(json_product1["category"]).to eq('Category 1')
           expect(json_product1["description"]).to eq('The product 1')
           expect(json_product1["image"]).to eq('http://www.product1.com')
           expect(json_product1["base_price"]).to eq(2000)
@@ -38,6 +48,7 @@ RSpec.describe "Products API" do
           expect(json_product2["id"]).to eq(product2.id)
           expect(json_product2["restaurant_id"]).to eq(product2.restaurant_id)
           expect(json_product2["name"]).to eq('Product 2')
+          expect(json_product2["category"]).to eq('Category 2')
           expect(json_product2["description"]).to eq('The product 2')
           expect(json_product2["image"]).to eq('http://www.product2.com')
           expect(json_product2["base_price"]).to eq(3000)
@@ -45,6 +56,7 @@ RSpec.describe "Products API" do
           expect(json_product3["id"]).to eq(product3.id)
           expect(json_product3["restaurant_id"]).to eq(product3.restaurant_id)
           expect(json_product3["name"]).to eq('Product 3')
+          expect(json_product3["category"]).to eq('Category 3')
           expect(json_product3["description"]).to eq('The product 3')
           expect(json_product3["image"]).to eq('http://www.product3.com')
           expect(json_product3["base_price"]).to eq(4000)

--- a/spec/requests/api/v1/restaurants/index_restaurants_spec.rb
+++ b/spec/requests/api/v1/restaurants/index_restaurants_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe "Restaurants API", type: :request do
           restaurant2 = create(:restaurant, restaurant_user: create(:restaurant_user),
                               name: 'Restaurante 2', image: 'http://www.restaurant2.com',
                               description: 'The restaurant 2')
-          create(:product, restaurant: restaurant2, category: restaurant1.categories.first)
+          create(:product, restaurant: restaurant2, category: restaurant2.categories.first)
           restaurant3 = create(:restaurant, restaurant_user: create(:restaurant_user),
                               name: 'Restaurante 3', image: 'http://www.restaurant3.com',
                               description: 'The restaurant 3')
-          create(:product, restaurant: restaurant3, category: restaurant1.categories.first)
+          create(:product, restaurant: restaurant3, category: restaurant3.categories.first)
           restaurant4 = create(:restaurant, restaurant_user: create(:restaurant_user),
                               name: 'Restaurante 4', image: 'http://www.restaurant4.com',
                               description: 'The restaurant 4')


### PR DESCRIPTION
Fecha a issue #117 

### Contexto
Na implementação anterior do endpoint de produtos, o campo **`category`** não estava sendo retornado no JSON.  
Além disso, foi identificada a necessidade de garantir que o produto e sua categoria pertençam ao mesmo restaurante.

### Alterações principais
- **`ProductsJson`** → inclusão do campo `category` no retorno da API.  
- **`Product` model** → adição da validação `category_belongs_to_same_restaurant`.  
- **`pt-BR.yml`** → adicionada mensagem de erro localizada.  
- **Testes**:
  - Atualização dos *request specs* para validar o retorno de `category`.  
  - Novo teste de modelo garantindo consistência entre `category` e `restaurant`.

### Resultados esperados
- O retorno da API agora inclui o nome da categoria associada ao produto.  
- Impede inconsistências ao associar produtos com categorias de outros restaurantes.  
- Cobertura de testes reforçada para manter integridade de domínio. 
